### PR TITLE
Add MetadataChanges.INCLUDE to offlineListen snippet.

### DIFF
--- a/firestore/app/src/main/java/com/google/example/firestore/DocSnippets.java
+++ b/firestore/app/src/main/java/com/google/example/firestore/DocSnippets.java
@@ -1169,7 +1169,7 @@ public class DocSnippets {
     public void offlineListen(FirebaseFirestore db) {
         // [START offline_listen]
         db.collection("cities").whereEqualTo("state", "CA")
-                .addSnapshotListener(new EventListener<QuerySnapshot>() {
+                .addSnapshotListener(MetadataChanges.INCLUDE, new EventListener<QuerySnapshot>() {
                     @Override
                     public void onEvent(@Nullable QuerySnapshot querySnapshot,
                                         @Nullable FirebaseFirestoreException e) {

--- a/firestore/app/src/main/java/com/google/example/firestore/kotlin/DocSnippets.kt
+++ b/firestore/app/src/main/java/com/google/example/firestore/kotlin/DocSnippets.kt
@@ -940,7 +940,7 @@ abstract class DocSnippets(val db: FirebaseFirestore) {
     fun offlineListen(db: FirebaseFirestore) {
         // [START offline_listen]
         db.collection("cities").whereEqualTo("state", "CA")
-                .addSnapshotListener(EventListener<QuerySnapshot> { querySnapshot, e ->
+                .addSnapshotListener(MetadataChanges.INCLUDE, EventListener<QuerySnapshot> { querySnapshot, e ->
                     if (e != null) {
                         Log.w(TAG, "Listen error", e)
                         return@EventListener


### PR DESCRIPTION
The docs mention this flag and we use it in all the other platforms, but it was missing from Android.

Used here: https://firebase.google.com/docs/firestore/manage-data/enable-offline#listen_to_offline_data