### PR TITLE
refactor: change commented snippets from java to kotlin

### DIFF
--- a/mlkit/app/src/main/java/com/google/firebase/example/mlkit/kotlin/BarcodeScanningActivity.kt
+++ b/mlkit/app/src/main/java/com/google/firebase/example/mlkit/kotlin/BarcodeScanningActivity.kt
@@ -21,8 +21,8 @@ class BarcodeScanningActivity : AppCompatActivity() {
         val detector = FirebaseVision.getInstance()
                 .visionBarcodeDetector
         // Or, to specify the formats to recognize:
-        // FirebaseVisionBarcodeDetector detector = FirebaseVision.getInstance()
-        //        .getVisionBarcodeDetector(options);
+        // val detector = FirebaseVision.getInstance()
+        //        .getVisionBarcodeDetector(options)
         // [END get_detector]
 
         // [START run_detector]

--- a/mlkit/app/src/main/java/com/google/firebase/example/mlkit/kotlin/ImageLabelingActivity.kt
+++ b/mlkit/app/src/main/java/com/google/firebase/example/mlkit/kotlin/ImageLabelingActivity.kt
@@ -67,8 +67,8 @@ class ImageLabelingActivity : AppCompatActivity() {
         val detector = FirebaseVision.getInstance()
                 .visionCloudLabelDetector
         // Or, to change the default settings:
-        // FirebaseVisionCloudLabelDetector detector = FirebaseVision.getInstance()
-        //         .getVisionCloudLabelDetector(options);
+        // val detector = FirebaseVision.getInstance()
+        //         .getVisionCloudLabelDetector(options)
         // [END get_detector_cloud]
 
         // [START run_detector_cloud]

--- a/mlkit/app/src/main/java/com/google/firebase/example/mlkit/kotlin/LandmarkRecognitionActivity.kt
+++ b/mlkit/app/src/main/java/com/google/firebase/example/mlkit/kotlin/LandmarkRecognitionActivity.kt
@@ -19,8 +19,8 @@ class LandmarkRecognitionActivity : AppCompatActivity() {
         val detector = FirebaseVision.getInstance()
                 .visionCloudLandmarkDetector
         // Or, to change the default settings:
-        // FirebaseVisionCloudLandmarkDetector detector = FirebaseVision.getInstance()
-        //         .getVisionCloudLandmarkDetector(options);
+        // val detector = FirebaseVision.getInstance()
+        //         .getVisionCloudLandmarkDetector(options)
         // [END get_detector_cloud]
 
         // [START run_detector_cloud]


### PR DESCRIPTION
The commented snippets were still in Java, although I've noticed the [documentation](https://firebase.google.com/docs/ml-kit/android/label-images) already has it in Kotlin. I suppose the documentation is not yet loading these snippets from this repo.