### PR TITLE
Demonstrate usage of FirebaseFirestore.runBatch() method

### DIFF
--- a/firestore/app/src/main/java/com/google/example/firestore/DocSnippets.java
+++ b/firestore/app/src/main/java/com/google/example/firestore/DocSnippets.java
@@ -587,23 +587,24 @@ public class DocSnippets {
 
     public void writeBatch() {
         // [START write_batch]
-        // Get a new write batch
-        WriteBatch batch = db.batch();
+        final DocumentReference nycRef = db.collection("cities").document("NYC");
+        final DocumentReference sfRef = db.collection("cities").document("SF");
+        final DocumentReference laRef = db.collection("cities").document("LA");
 
-        // Set the value of 'NYC'
-        DocumentReference nycRef = db.collection("cities").document("NYC");
-        batch.set(nycRef, new City());
+        // Get a new write batch and commit all write operations
+        db.runBatch(new WriteBatch.Function() {
+            @Override
+            public void apply(@NonNull WriteBatch batch) {
+                // Set the value of 'NYC'
+                batch.set(nycRef, new City());
 
-        // Update the population of 'SF'
-        DocumentReference sfRef = db.collection("cities").document("SF");
-        batch.update(sfRef, "population", 1000000L);
+                // Update the population of 'SF'
+                batch.update(sfRef, "population", 1000000L);
 
-        // Delete the city 'LA'
-        DocumentReference laRef = db.collection("cities").document("LA");
-        batch.delete(laRef);
-
-        // Commit the batch
-        batch.commit().addOnCompleteListener(new OnCompleteListener<Void>() {
+                // Delete the city 'LA'
+                batch.delete(laRef);
+            }
+        }).addOnCompleteListener(new OnCompleteListener<Void>() {
             @Override
             public void onComplete(@NonNull Task<Void> task) {
                 // ...

--- a/firestore/app/src/main/java/com/google/example/firestore/DocSnippets.java
+++ b/firestore/app/src/main/java/com/google/example/firestore/DocSnippets.java
@@ -587,24 +587,23 @@ public class DocSnippets {
 
     public void writeBatch() {
         // [START write_batch]
-        final DocumentReference nycRef = db.collection("cities").document("NYC");
-        final DocumentReference sfRef = db.collection("cities").document("SF");
-        final DocumentReference laRef = db.collection("cities").document("LA");
+        // Get a new write batch
+        WriteBatch batch = db.batch();
 
-        // Get a new write batch and commit all write operations
-        db.runBatch(new WriteBatch.Function() {
-            @Override
-            public void apply(@NonNull WriteBatch batch) {
-                // Set the value of 'NYC'
-                batch.set(nycRef, new City());
+        // Set the value of 'NYC'
+        DocumentReference nycRef = db.collection("cities").document("NYC");
+        batch.set(nycRef, new City());
 
-                // Update the population of 'SF'
-                batch.update(sfRef, "population", 1000000L);
+        // Update the population of 'SF'
+        DocumentReference sfRef = db.collection("cities").document("SF");
+        batch.update(sfRef, "population", 1000000L);
 
-                // Delete the city 'LA'
-                batch.delete(laRef);
-            }
-        }).addOnCompleteListener(new OnCompleteListener<Void>() {
+        // Delete the city 'LA'
+        DocumentReference laRef = db.collection("cities").document("LA");
+        batch.delete(laRef);
+
+        // Commit the batch
+        batch.commit().addOnCompleteListener(new OnCompleteListener<Void>() {
             @Override
             public void onComplete(@NonNull Task<Void> task) {
                 // ...

--- a/firestore/app/src/main/java/com/google/example/firestore/kotlin/DocSnippets.kt
+++ b/firestore/app/src/main/java/com/google/example/firestore/kotlin/DocSnippets.kt
@@ -433,23 +433,21 @@ abstract class DocSnippets(val db: FirebaseFirestore) {
 
     fun writeBatch() {
         // [START write_batch]
-        // Get a new write batch
-        val batch = db.batch()
-
-        // Set the value of 'NYC'
         val nycRef = db.collection("cities").document("NYC")
-        batch.set(nycRef, City())
-
-        // Update the population of 'SF'
         val sfRef = db.collection("cities").document("SF")
-        batch.update(sfRef, "population", 1000000L)
-
-        // Delete the city 'LA'
         val laRef = db.collection("cities").document("LA")
-        batch.delete(laRef)
 
-        // Commit the batch
-        batch.commit().addOnCompleteListener {
+        // Get a new write batch and commit all writes operations
+        db.runBatch { batch ->
+            // Set the value of 'NYC'
+            batch.set(nycRef, City())
+
+            // Update the population of 'SF'
+            batch.update(sfRef, "population", 1000000L)
+
+            // Delete the city 'LA'
+            batch.delete(laRef)
+        }.addOnCompleteListener {
             // ...
         }
         // [END write_batch]

--- a/firestore/app/src/main/java/com/google/example/firestore/kotlin/DocSnippets.kt
+++ b/firestore/app/src/main/java/com/google/example/firestore/kotlin/DocSnippets.kt
@@ -437,7 +437,7 @@ abstract class DocSnippets(val db: FirebaseFirestore) {
         val sfRef = db.collection("cities").document("SF")
         val laRef = db.collection("cities").document("LA")
 
-        // Get a new write batch and commit all writes operations
+        // Get a new write batch and commit all write operations
         db.runBatch { batch ->
             // Set the value of 'NYC'
             batch.set(nycRef, City())


### PR DESCRIPTION
Starting in version 18.2.0, the Cloud Firestore Android SDK includes a `FirebaseFirestore.runBatch()` method which executes a `batchFunction` on a new `WriteBatch` and then commits all of the writes made by that `batchFunction`.