### PR TITLE
feat: add snippets for firestore server-side deletes solution

### DIFF
--- a/firestore/app/build.gradle
+++ b/firestore/app/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     // Firebase / Play Services
     implementation "com.google.firebase:firebase-auth:19.1.0"
     implementation "com.google.android.gms:play-services-auth:17.0.0"
+    implementation "com.google.firebase:firebase-functions:19.0.1"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.50"
 }
 

--- a/firestore/app/src/main/java/com/google/example/firestore/SolutionDeletes.java
+++ b/firestore/app/src/main/java/com/google/example/firestore/SolutionDeletes.java
@@ -1,0 +1,44 @@
+package com.google.example.firestore;
+
+import androidx.annotation.NonNull;
+
+import com.google.android.gms.tasks.OnFailureListener;
+import com.google.android.gms.tasks.OnSuccessListener;
+import com.google.firebase.functions.FirebaseFunctions;
+import com.google.firebase.functions.HttpsCallableReference;
+import com.google.firebase.functions.HttpsCallableResult;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class SolutionDeletes {
+
+    // [START call_delete_function]
+    /**
+     * Call the 'recursiveDelete' callable function with a path to initiate
+     * a server-side delete.
+     */
+    public void deleteAtPath(String path) {
+        Map<String, Object> data = new HashMap<>();
+        data.put("path", path);
+
+        HttpsCallableReference deleteFn =
+                FirebaseFunctions.getInstance().getHttpsCallable("recursiveDelete");
+        deleteFn.call(data)
+                .addOnSuccessListener(new OnSuccessListener<HttpsCallableResult>() {
+                    @Override
+                    public void onSuccess(HttpsCallableResult httpsCallableResult) {
+                        // Delete Success
+                        // ...
+                    }
+                })
+                .addOnFailureListener(new OnFailureListener() {
+                    @Override
+                    public void onFailure(@NonNull Exception e) {
+                        // Delete failed
+                        // ...
+                    }
+                });
+    }
+    // [END call_delete_function]
+}

--- a/firestore/app/src/main/java/com/google/example/firestore/kotlin/SolutionDeletes.kt
+++ b/firestore/app/src/main/java/com/google/example/firestore/kotlin/SolutionDeletes.kt
@@ -1,0 +1,25 @@
+package com.google.example.firestore.kotlin
+
+import com.google.firebase.functions.FirebaseFunctions
+
+class SolutionDeletes {
+
+    // [START call_delete_function]
+    /**
+     * Call the 'recursiveDelete' callable function with a path to initiate
+     * a server-side delete.
+     */
+    fun deleteAtPath(path: String) {
+        val deleteFn = FirebaseFunctions.getInstance().getHttpsCallable("recursiveDelete")
+        deleteFn.call(hashMapOf("path" to path))
+                .addOnSuccessListener {
+                    // Delete Success
+                    // ...
+                }
+                .addOnFailureListener {
+                    // Delete Failed
+                    // ...
+                }
+    }
+    // [END call_delete_function]
+}


### PR DESCRIPTION
Was wondering if we could have the Android version of [Client Implementation of the Firestore Delete Solution](https://firebase.google.com/docs/firestore/solutions/delete-collections#client_invocation) on the Documentation?