### PR TITLE
add mlkit interpreter 22.0.0 snippets

### DIFF
--- a/database/app/build.gradle
+++ b/database/app/build.gradle
@@ -29,7 +29,7 @@ android {
 dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation "com.google.firebase:firebase-database:19.1.0"
+    implementation "com.google.firebase:firebase-database:19.2.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.50"
 }
 

--- a/dynamic-links/app/build.gradle
+++ b/dynamic-links/app/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation "com.google.firebase:firebase-auth:19.1.0"
     implementation "com.google.firebase:firebase-invites:17.0.0"
-    implementation "com.google.firebase:firebase-database:19.1.0"
+    implementation "com.google.firebase:firebase-database:19.2.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.50"
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
 }

--- a/firebaseoptions/app/build.gradle
+++ b/firebaseoptions/app/build.gradle
@@ -24,7 +24,7 @@ android {
 dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation "com.google.firebase:firebase-database:19.1.0"
+    implementation "com.google.firebase:firebase-database:19.2.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.50"
 }
 

--- a/firestore/app/build.gradle
+++ b/firestore/app/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     implementation 'androidx.multidex:multidex:2.0.1'
 
     // Firestore
-    implementation "com.google.firebase:firebase-firestore:21.1.1"
+    implementation "com.google.firebase:firebase-firestore:21.2.0"
 
     // Firebase / Play Services
     implementation "com.google.firebase:firebase-auth:19.1.0"

--- a/mlkit/app/build.gradle
+++ b/mlkit/app/build.gradle
@@ -29,9 +29,9 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.exifinterface:exifinterface:1.0.0'
-    implementation "com.google.firebase:firebase-ml-common:21.0.0"
-    implementation "com.google.firebase:firebase-ml-model-interpreter:21.0.0"
-    implementation "com.google.firebase:firebase-ml-vision:23.0.0"
+    implementation "com.google.firebase:firebase-ml-common:22.0.0"
+    implementation "com.google.firebase:firebase-ml-model-interpreter:22.0.0"
+    implementation "com.google.firebase:firebase-ml-vision:24.0.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.50"
 }
 

--- a/mlkit/app/src/main/java/com/google/firebase/example/mlkit/CustomModelActivity.java
+++ b/mlkit/app/src/main/java/com/google/firebase/example/mlkit/CustomModelActivity.java
@@ -2,7 +2,6 @@ package com.google.firebase.example.mlkit;
 
 import android.graphics.Bitmap;
 import android.graphics.Color;
-import android.os.Build;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import android.util.Log;
@@ -10,15 +9,13 @@ import android.util.Log;
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.firebase.ml.common.FirebaseMLException;
-import com.google.firebase.ml.common.modeldownload.FirebaseLocalModel;
-import com.google.firebase.ml.common.modeldownload.FirebaseModelDownloadConditions;
-import com.google.firebase.ml.common.modeldownload.FirebaseModelManager;
-import com.google.firebase.ml.common.modeldownload.FirebaseRemoteModel;
+import com.google.firebase.ml.custom.FirebaseCustomLocalModel;
+import com.google.firebase.ml.custom.FirebaseCustomRemoteModel;
 import com.google.firebase.ml.custom.FirebaseModelDataType;
 import com.google.firebase.ml.custom.FirebaseModelInputOutputOptions;
 import com.google.firebase.ml.custom.FirebaseModelInputs;
 import com.google.firebase.ml.custom.FirebaseModelInterpreter;
-import com.google.firebase.ml.custom.FirebaseModelOptions;
+import com.google.firebase.ml.custom.FirebaseModelInterpreterOptions;
 import com.google.firebase.ml.custom.FirebaseModelOutputs;
 
 import java.io.BufferedReader;
@@ -29,48 +26,32 @@ public class CustomModelActivity extends AppCompatActivity {
 
     private void configureHostedModelSource() {
         // [START mlkit_cloud_model_source]
-        FirebaseModelDownloadConditions.Builder conditionsBuilder =
-                new FirebaseModelDownloadConditions.Builder().requireWifi();
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            // Enable advanced conditions on Android Nougat and newer.
-            conditionsBuilder = conditionsBuilder
-                    .requireCharging()
-                    .requireDeviceIdle();
-        }
-        FirebaseModelDownloadConditions conditions = conditionsBuilder.build();
-
-        // Build a remote model source object by specifying the name you assigned the model
-        // when you uploaded it in the Firebase console.
-        FirebaseRemoteModel cloudSource = new FirebaseRemoteModel.Builder("my_cloud_model")
-                .enableModelUpdates(true)
-                .setInitialDownloadConditions(conditions)
-                .setUpdatesDownloadConditions(conditions)
-                .build();
-        FirebaseModelManager.getInstance().registerRemoteModel(cloudSource);
+        FirebaseCustomRemoteModel remoteModel =
+                new FirebaseCustomRemoteModel.Builder("your_model").build();
         // [END mlkit_cloud_model_source]
     }
 
     private void configureLocalModelSource() {
         // [START mlkit_local_model_source]
-        FirebaseLocalModel localSource =
-                new FirebaseLocalModel.Builder("my_local_model")  // Assign a name to this model
-                        .setAssetFilePath("my_model.tflite")
-                        .build();
-        FirebaseModelManager.getInstance().registerLocalModel(localSource);
+        FirebaseCustomLocalModel localModel = new FirebaseCustomLocalModel.Builder()
+                .setAssetFilePath("your_model.tflite")
+                .build();
         // [END mlkit_local_model_source]
     }
 
-    private FirebaseModelInterpreter createInterpreter() throws FirebaseMLException {
+    private FirebaseModelInterpreter createInterpreter(FirebaseCustomLocalModel localModel) throws FirebaseMLException {
         // [START mlkit_create_interpreter]
-        FirebaseModelOptions options = new FirebaseModelOptions.Builder()
-                .setRemoteModelName("my_cloud_model")
-                .setLocalModelName("my_local_model")
-                .build();
-        FirebaseModelInterpreter firebaseInterpreter =
-                FirebaseModelInterpreter.getInstance(options);
+        FirebaseModelInterpreter interpreter = null;
+        try {
+            FirebaseModelInterpreterOptions options =
+                    new FirebaseModelInterpreterOptions.Builder(localModel).build();
+            interpreter = FirebaseModelInterpreter.getInstance(options);
+        } catch (FirebaseMLException e) {
+            // ...
+        }
         // [END mlkit_create_interpreter]
 
-        return firebaseInterpreter;
+        return interpreter;
     }
 
     private FirebaseModelInputOutputOptions createInputOutputOptions() throws FirebaseMLException {
@@ -109,7 +90,8 @@ public class CustomModelActivity extends AppCompatActivity {
     }
 
     private void runInference() throws FirebaseMLException {
-        FirebaseModelInterpreter firebaseInterpreter = createInterpreter();
+        FirebaseCustomLocalModel localModel = new FirebaseCustomLocalModel.Builder().build();
+        FirebaseModelInterpreter firebaseInterpreter = createInterpreter(localModel);
         float[][][][] input = bitmapToInputArray();
         FirebaseModelInputOutputOptions inputOutputOptions = createInputOutputOptions();
 

--- a/mlkit/app/src/main/java/com/google/firebase/example/mlkit/kotlin/CustomModelActivity.kt
+++ b/mlkit/app/src/main/java/com/google/firebase/example/mlkit/kotlin/CustomModelActivity.kt
@@ -8,6 +8,8 @@ import androidx.appcompat.app.AppCompatActivity
 import android.util.Log
 import com.google.android.gms.tasks.OnFailureListener
 import com.google.firebase.ml.common.FirebaseMLException
+import com.google.firebase.ml.common.modeldownload.FirebaseModelDownloadConditions
+import com.google.firebase.ml.common.modeldownload.FirebaseModelManager
 import com.google.firebase.ml.custom.FirebaseCustomLocalModel
 import com.google.firebase.ml.custom.FirebaseCustomRemoteModel
 import com.google.firebase.ml.custom.FirebaseModelInterpreterOptions
@@ -33,6 +35,18 @@ class CustomModelActivity : AppCompatActivity() {
         // [END mlkit_cloud_model_source]
     }
 
+    private fun startModelDownloadTask(remoteModel: FirebaseCustomRemoteModel) {
+        // [START mlkit_model_download_task]
+        val conditions = FirebaseModelDownloadConditions.Builder()
+                .requireWifi()
+                .build()
+        FirebaseModelManager.getInstance().download(remoteModel, conditions)
+                .addOnCompleteListener {
+                    // Success.
+                }
+        // [END mlkit_model_download_task]
+    }
+
     private fun configureLocalModelSource() {
         // [START mlkit_local_model_source]
         val localModel = FirebaseCustomLocalModel.Builder()
@@ -49,6 +63,34 @@ class CustomModelActivity : AppCompatActivity() {
         // [END mlkit_create_interpreter]
 
         return interpreter
+    }
+
+    private fun checkModelDownloadStatus(remoteModel: FirebaseCustomRemoteModel, localModel: FirebaseCustomLocalModel) {
+        // [START mlkit_check_download_status]
+        FirebaseModelManager.getInstance().isModelDownloaded(remoteModel)
+                .addOnSuccessListener { isDownloaded ->
+                    val options =
+                            if (isDownloaded) {
+                                FirebaseModelInterpreterOptions.Builder(remoteModel).build()
+                            } else {
+                                FirebaseModelInterpreterOptions.Builder(localModel).build()
+                            }
+                    val interpreter = FirebaseModelInterpreter.getInstance(options)
+                }
+        // [END mlkit_check_download_status]
+    }
+
+    private fun addDownloadListener(
+            remoteModel: FirebaseCustomRemoteModel,
+            conditions: FirebaseModelDownloadConditions
+    ) {
+        // [START mlkit_remote_model_download_listener]
+        FirebaseModelManager.getInstance().download(remoteModel, conditions)
+                .addOnCompleteListener {
+                    // Download complete. Depending on your app, you could enable the ML
+                    // feature, or switch from the local model to the remote model, etc.
+                }
+        // [END mlkit_remote_model_download_listener]
     }
 
     @Throws(FirebaseMLException::class)

--- a/perf/app/build.gradle
+++ b/perf/app/build.gradle
@@ -24,7 +24,7 @@ android {
 dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation "com.google.firebase:firebase-config:19.0.2"
+    implementation "com.google.firebase:firebase-config:19.0.3"
     implementation "com.google.firebase:firebase-perf:19.0.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.50"
 }

--- a/predictions/app/build.gradle
+++ b/predictions/app/build.gradle
@@ -28,6 +28,6 @@ dependencies {
 
     implementation "com.google.firebase:firebase-ads:18.2.0"
     implementation "com.google.firebase:firebase-analytics:17.2.0"
-    implementation "com.google.firebase:firebase-config:19.0.2"
+    implementation "com.google.firebase:firebase-config:19.0.3"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.50"
 }


### PR DESCRIPTION
Currently, our automatic build is failing in #141 because MLKit v22.0.0 introduces some [breaking changes](https://firebase.google.com/support/release-notes/android#mlkit-model-interpreter_v22-0-0).

I've also noticed that in order to accommodate these changes, the [devsite](https://firebase.google.com/docs/ml-kit/android/use-custom-models) is no longer loading some of the snippets from this repository.

This PR should:
- Address the breaking changes to fix our automatic build (using snippets from the devsite);
- Add the new snippets to this repository so that the devsite can load from here again. PS: the new snippets are under the tags `mlkit_model_download_task`, `mlkit_check_download_status` and `mlkit_remote_model_download_listener`.