### PR TITLE
Fixed `AppIndexingUpdateService` race condition

### DIFF
--- a/appindexing/app/src/main/java/com/google/firebase/example/appindexing/AppIndexingUpdateService.java
+++ b/appindexing/app/src/main/java/com/google/firebase/example/appindexing/AppIndexingUpdateService.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import androidx.annotation.NonNull;
 import androidx.core.app.JobIntentService;
 
+import com.google.android.gms.tasks.Tasks
 import com.google.firebase.appindexing.FirebaseAppIndex;
 import com.google.firebase.appindexing.Indexable;
 import com.google.firebase.appindexing.builders.Indexables;
@@ -49,7 +50,13 @@ public class AppIndexingUpdateService extends JobIntentService {
             notesArr = indexableNotes.toArray(notesArr);
 
             // batch insert indexable notes into index
-            FirebaseAppIndex.getInstance().update(notesArr);
+            try {
+                Tasks.await(FirebaseAppIndex.getInstance().update(notesArr));
+            } catch (ExecutionException e) {
+                // update failed
+            } catch (InterruptedException e) {
+                // await was interrupted
+            }
         }
     }
 

--- a/appindexing/app/src/main/java/com/google/firebase/example/appindexing/AppIndexingUpdateService.java
+++ b/appindexing/app/src/main/java/com/google/firebase/example/appindexing/AppIndexingUpdateService.java
@@ -5,7 +5,7 @@ import android.content.Intent;
 import androidx.annotation.NonNull;
 import androidx.core.app.JobIntentService;
 
-import com.google.android.gms.tasks.Tasks
+import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.appindexing.FirebaseAppIndex;
 import com.google.firebase.appindexing.Indexable;
 import com.google.firebase.appindexing.builders.Indexables;

--- a/appindexing/app/src/main/java/com/google/firebase/example/appindexing/AppIndexingUpdateService.java
+++ b/appindexing/app/src/main/java/com/google/firebase/example/appindexing/AppIndexingUpdateService.java
@@ -16,6 +16,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import java.util.concurrent.ExecutionException;
+
 // [START appindexing_update_service]
 public class AppIndexingUpdateService extends JobIntentService {
 

--- a/appindexing/app/src/main/java/com/google/firebase/example/appindexing/kotlin/AppIndexingUpdateService.kt
+++ b/appindexing/app/src/main/java/com/google/firebase/example/appindexing/kotlin/AppIndexingUpdateService.kt
@@ -3,6 +3,7 @@ package com.google.firebase.example.appindexing.kotlin
 import android.content.Context
 import android.content.Intent
 import androidx.core.app.JobIntentService
+import com.google.android.gms.tasks.Tasks
 import com.google.firebase.appindexing.FirebaseAppIndex
 import com.google.firebase.appindexing.Indexable
 import com.google.firebase.appindexing.builders.Indexables
@@ -43,7 +44,13 @@ class AppIndexingUpdateService : JobIntentService() {
             val notesArr: Array<Indexable> = indexableNotes.toTypedArray()
 
             // batch insert indexable notes into index
-            FirebaseAppIndex.getInstance().update(*notesArr)
+            try {
+                Tasks.await(FirebaseAppIndex.getInstance().update(*notesArr))
+            } catch (ExecutionException e) {
+                // update failed
+            } catch (InterruptedException e) {
+                // await was interrupted
+            }
         }
     }
 

--- a/appindexing/app/src/main/java/com/google/firebase/example/appindexing/kotlin/AppIndexingUpdateService.kt
+++ b/appindexing/app/src/main/java/com/google/firebase/example/appindexing/kotlin/AppIndexingUpdateService.kt
@@ -8,6 +8,7 @@ import com.google.firebase.appindexing.FirebaseAppIndex
 import com.google.firebase.appindexing.Indexable
 import com.google.firebase.appindexing.builders.Indexables
 import com.google.firebase.example.appindexing.model.Recipe
+import java.util.concurrent.ExecutionException
 
 // [START appindexing_update_service]
 class AppIndexingUpdateService : JobIntentService() {

--- a/appindexing/app/src/main/java/com/google/firebase/example/appindexing/kotlin/AppIndexingUpdateService.kt
+++ b/appindexing/app/src/main/java/com/google/firebase/example/appindexing/kotlin/AppIndexingUpdateService.kt
@@ -46,9 +46,9 @@ class AppIndexingUpdateService : JobIntentService() {
             // batch insert indexable notes into index
             try {
                 Tasks.await(FirebaseAppIndex.getInstance().update(*notesArr))
-            } catch (ExecutionException e) {
+            } catch (e: ExecutionException) {
                 // update failed
-            } catch (InterruptedException e) {
+            } catch (e: InterruptedException) {
                 // await was interrupted
             }
         }


### PR DESCRIPTION
`AppindexingUpdateService` had a race condition because its call to `FirebaseAppIndex#update` is asynchronous, but `IntentService#onHandleIntent` is a synchronous method. The solution is to `Tasks#await` the `Task` that `FirebaseAppindex#update` returns.