### PR TITLE
Kotlin, "region" field name should be "regions"

### DIFF
--- a/firestore/app/src/main/java/com/google/example/firestore/kotlin/DocSnippets.kt
+++ b/firestore/app/src/main/java/com/google/example/firestore/kotlin/DocSnippets.kt
@@ -832,7 +832,7 @@ abstract class DocSnippets(val db: FirebaseFirestore) {
         // [START array_contains_any_filter]
         val citiesRef = db.collection("cities")
 
-        citiesRef.whereArrayContainsAny("region", listOf("west_coast", "east_coast"))
+        citiesRef.whereArrayContainsAny("regions", listOf("west_coast", "east_coast"))
         // [END array_contains_any_filter]
     }
 


### PR DESCRIPTION
Fixed Android snippet in previous PR but I missed the Kotlin snippet.