### PR TITLE
chore(admob, auth, iam, predictions): migrate to Java 8

### DIFF
--- a/admob/app/build.gradle
+++ b/admob/app/build.gradle
@@ -19,6 +19,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    compileOptions {
+        sourceCompatibility '1.8'
+        targetCompatibility '1.8'
+    }
 }
 
 dependencies {

--- a/admob/app/build.gradle
+++ b/admob/app/build.gradle
@@ -23,7 +23,7 @@ android {
 
 dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.browser:browser:1.0.0'
+    implementation 'androidx.browser:browser:1.2.0'
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation "com.google.firebase:firebase-ads:18.3.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.61"

--- a/auth/app/build.gradle
+++ b/auth/app/build.gradle
@@ -18,6 +18,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    compileOptions {
+        sourceCompatibility '1.8'
+        targetCompatibility '1.8'
+    }
 }
 
 dependencies {

--- a/auth/app/build.gradle
+++ b/auth/app/build.gradle
@@ -23,7 +23,7 @@ android {
 dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.browser:browser:1.0.0'
+    implementation 'androidx.browser:browser:1.2.0'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'com.google.android.material:material:1.0.0'
 

--- a/inappmessaging/app/build.gradle
+++ b/inappmessaging/app/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.browser:browser:1.0.0'
+    implementation 'androidx.browser:browser:1.2.0'
 
     implementation "com.google.firebase:firebase-inappmessaging-display:19.0.2"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.61"

--- a/inappmessaging/app/build.gradle
+++ b/inappmessaging/app/build.gradle
@@ -20,6 +20,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    compileOptions {
+        sourceCompatibility '1.8'
+        targetCompatibility '1.8'
+    }
 }
 
 dependencies {

--- a/inappmessaging/app/build.gradle
+++ b/inappmessaging/app/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.browser:browser:1.2.0'
+    implementation 'com.google.guava:guava:28.2-android'
 
     implementation "com.google.firebase:firebase-inappmessaging-display:19.0.2"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.61"

--- a/perf/app/build.gradle
+++ b/perf/app/build.gradle
@@ -24,7 +24,7 @@ android {
 dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation "com.google.firebase:firebase-config:19.0.4"
-    implementation "com.google.firebase:firebase-perf:19.0.3"
+    implementation "com.google.firebase:firebase-config:19.1.0"
+    implementation "com.google.firebase:firebase-perf:19.0.4"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.61"
 }

--- a/predictions/app/build.gradle
+++ b/predictions/app/build.gradle
@@ -19,6 +19,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    compileOptions {
+        sourceCompatibility '1.8'
+        targetCompatibility '1.8'
+    }
 }
 
 dependencies {

--- a/predictions/app/build.gradle
+++ b/predictions/app/build.gradle
@@ -23,11 +23,11 @@ android {
 
 dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.browser:browser:1.0.0'
+    implementation 'androidx.browser:browser:1.2.0'
     implementation 'androidx.appcompat:appcompat:1.1.0'
 
     implementation "com.google.firebase:firebase-ads:18.3.0"
     implementation "com.google.firebase:firebase-analytics:17.2.1"
-    implementation "com.google.firebase:firebase-config:19.0.4"
+    implementation "com.google.firebase:firebase-config:19.1.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.61"
 }


### PR DESCRIPTION
I managed to fix the error in #164 by adding the lines below to the modules using the androidx.browser package:
```groovy
compileOptions {
        sourceCompatibility '1.8'
        targetCompatibility '1.8'
}
```