### PR TITLE
chore: implement selective builds on GitHub Actions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,9 +13,13 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
-    - name: Install NDK
-      run: echo "y" | sudo ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;20.0.5594570" --sdk_root=${ANDROID_SDK_ROOT}
     - name: Check Snippets
       run: python scripts/checksnippets.py
-    - name: Build with Gradle
+    - name: Install NDK
+      run: echo "y" | sudo ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;20.0.5594570" --sdk_root=${ANDROID_SDK_ROOT}
+    - name: Build with Gradle (Pull Request)
+      run: ./build_pull_request.sh
+      if: github.event_name == 'pull_request'
+    - name: Build with Gradle (Push)
       run: ./gradlew clean ktlint build
+      if: github.event_name != 'pull_request'

--- a/build_pull_request.sh
+++ b/build_pull_request.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Exit on error
+set -e
+
+# unshallow since GitHub actions does a shallow clone
+git fetch --unshallow
+git fetch origin
+
+# Get all the modules that were changed
+while read line; do
+  module_name=${line%%/*}
+  if [[ ${MODULES} != *"${module_name}"* ]]; then
+    MODULES="${MODULES} ${module_name}"
+  fi
+done < <(git diff --name-only origin/$GITHUB_BASE_REF)
+changed_modules=$MODULES
+
+# Get a list of all available gradle tasks
+AVAILABLE_TASKS=$(./gradlew tasks --all)
+
+# Check if these modules have gradle tasks
+build_commands=""
+for module in $changed_modules
+do
+  if [[ $AVAILABLE_TASKS =~ $module":app:" ]]; then
+    build_commands=${build_commands}" :"${module}":app:assembleDebug :"${module}":app:check"
+  fi
+done
+
+# Build
+echo "Building Pull Request with"
+echo $build_commands
+eval "./gradlew clean ktlint ${build_commands}"


### PR DESCRIPTION
Same as firebase/quickstart-android#1094

Notice that here I've also changed the order of "Install NDK" and "Check Snippets", since there's no point in installing the NDK if the build will eventually fail because of mispelled snippets.