### PR TITLE
refactor(firestore): use Functions KTX on Kotlin snippet

### DIFF
--- a/firestore/app/build.gradle
+++ b/firestore/app/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     // Firebase / Play Services
     implementation "com.google.firebase:firebase-auth:19.3.1"
     implementation "com.google.android.gms:play-services-auth:18.0.0"
-    implementation "com.google.firebase:firebase-functions:19.0.2"
+    implementation "com.google.firebase:firebase-functions-ktx:19.0.2"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.72"
 }
 

--- a/firestore/app/src/main/java/com/google/example/firestore/kotlin/SolutionDeletes.kt
+++ b/firestore/app/src/main/java/com/google/example/firestore/kotlin/SolutionDeletes.kt
@@ -1,6 +1,7 @@
 package com.google.example.firestore.kotlin
 
-import com.google.firebase.functions.FirebaseFunctions
+import com.google.firebase.functions.ktx.functions
+import com.google.firebase.ktx.Firebase
 
 class SolutionDeletes {
 
@@ -10,7 +11,7 @@ class SolutionDeletes {
      * a server-side delete.
      */
     fun deleteAtPath(path: String) {
-        val deleteFn = FirebaseFunctions.getInstance().getHttpsCallable("recursiveDelete")
+        val deleteFn = Firebase.functions.getHttpsCallable("recursiveDelete")
         deleteFn.call(hashMapOf("path" to path))
                 .addOnSuccessListener {
                     // Delete Success


### PR DESCRIPTION
This should refactor our firestore snippets to use Functions KTX.

Btw, @samtstern I had added this snippet in #139 but it's not yet displayed on the Documentation. I hope it's not hard to add it.