### PR TITLE
Change commented method call to the correct method

### DIFF
--- a/firebaseoptions/app/src/main/java/devrel/firebase/google/com/firebaseoptions/kotlin/MainActivity.kt
+++ b/firebaseoptions/app/src/main/java/devrel/firebase/google/com/firebaseoptions/kotlin/MainActivity.kt
@@ -24,8 +24,8 @@ class MainActivity : AppCompatActivity() {
                 .setProjectId("my-firebase-project")
                 .setApplicationId("1:27992087142:android:ce3b6448250083d1")
                 .setApiKey("AIzaSyADUe90ULnQDuGShD9W23RDP0xmeDc6Mvw")
-                // setDatabaseURL(...)
-                // setStorageBucket(...)
+                // .setDatabaseUrl(...)
+                // .setStorageBucket(...)
                 .build()
         // [END firebase_options]
 


### PR DESCRIPTION
See https://firebase.google.com/docs/reference/android/com/google/firebase/FirebaseOptions.Builder#public-firebaseoptions.builder-setdatabaseurl-string-databaseurl
which doesn't use setDatabaseURL.
Also included the `.` before the commented method calls to directly allow code uncommenting