### PR TITLE
refactor(storage): improve code snippets

### DIFF
--- a/storage/app/src/main/java/com/google/firebase/referencecode/storage/StorageActivity.java
+++ b/storage/app/src/main/java/com/google/firebase/referencecode/storage/StorageActivity.java
@@ -20,6 +20,7 @@ import android.graphics.Bitmap;
 import android.graphics.drawable.BitmapDrawable;
 import android.net.Uri;
 import android.os.Bundle;
+import android.util.Log;
 import android.widget.ImageView;
 
 import androidx.annotation.NonNull;
@@ -51,6 +52,7 @@ import java.io.InputStream;
 import java.util.List;
 
 public class StorageActivity extends AppCompatActivity {
+    private final String TAG = "java.StorageActivity";
     // [START storage_field_declaration]
     // [END storage_field_declaration]
 
@@ -261,12 +263,12 @@ public class StorageActivity extends AppCompatActivity {
             @Override
             public void onProgress(UploadTask.TaskSnapshot taskSnapshot) {
                 double progress = (100.0 * taskSnapshot.getBytesTransferred()) / taskSnapshot.getTotalByteCount();
-                System.out.println("Upload is " + progress + "% done");
+                Log.d(TAG, "Upload is " + progress + "% done");
             }
         }).addOnPausedListener(new OnPausedListener<UploadTask.TaskSnapshot>() {
             @Override
             public void onPaused(UploadTask.TaskSnapshot taskSnapshot) {
-                System.out.println("Upload is paused");
+                Log.d(TAG, "Upload is paused");
             }
         });
         // [END monitor_upload_progress]
@@ -288,12 +290,12 @@ public class StorageActivity extends AppCompatActivity {
             @Override
             public void onProgress(UploadTask.TaskSnapshot taskSnapshot) {
                 double progress = (100.0 * taskSnapshot.getBytesTransferred()) / taskSnapshot.getTotalByteCount();
-                System.out.println("Upload is " + progress + "% done");
+                Log.d(TAG, "Upload is " + progress + "% done");
             }
         }).addOnPausedListener(new OnPausedListener<UploadTask.TaskSnapshot>() {
             @Override
             public void onPaused(UploadTask.TaskSnapshot taskSnapshot) {
-                System.out.println("Upload is paused");
+                Log.d(TAG, "Upload is paused");
             }
         }).addOnFailureListener(new OnFailureListener() {
             @Override

--- a/storage/app/src/main/java/com/google/firebase/referencecode/storage/kotlin/DownloadActivity.kt
+++ b/storage/app/src/main/java/com/google/firebase/referencecode/storage/kotlin/DownloadActivity.kt
@@ -10,7 +10,7 @@ import com.google.firebase.storage.ktx.storage
 class DownloadActivity : AppCompatActivity() {
 
     // storageRef was previously used to transfer data.
-    private var storageRef: StorageReference? = null
+    private lateinit var storageRef: StorageReference
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -22,9 +22,7 @@ class DownloadActivity : AppCompatActivity() {
         super.onSaveInstanceState(outState)
 
         // If there's a download in progress, save the reference so you can query it later
-        storageRef?.let {
-            outState.putString("reference", it.toString())
-        }
+        outState.putString("reference", storageRef.toString())
     }
 
     override fun onRestoreInstanceState(savedInstanceState: Bundle) {
@@ -36,18 +34,16 @@ class DownloadActivity : AppCompatActivity() {
         storageRef = Firebase.storage.getReferenceFromUrl(stringRef)
 
         // Find all DownloadTasks under this StorageReference (in this example, there should be one)
-        val tasks = storageRef?.activeDownloadTasks
+        val tasks = storageRef.activeDownloadTasks
 
-        tasks?.size?.let { it ->
-            if (it > 0) {
-                // Get the task monitoring the download
-                val task = tasks[0]
+        if (tasks.size > 0) {
+            // Get the task monitoring the download
+            val task = tasks[0]
 
-                // Add new listeners to the task using an Activity scope
-                task.addOnSuccessListener(this) {
-                    // Success!
-                    // ...
-                }
+            // Add new listeners to the task using an Activity scope
+            task.addOnSuccessListener(this) {
+                // Success!
+                // ...
             }
         }
     }

--- a/storage/app/src/main/java/com/google/firebase/referencecode/storage/kotlin/StorageActivity.kt
+++ b/storage/app/src/main/java/com/google/firebase/referencecode/storage/kotlin/StorageActivity.kt
@@ -209,6 +209,8 @@ abstract class StorageActivity : AppCompatActivity() {
 
         // [START monitor_upload_progress]
         // Observe state change events such as progress, pause, and resume
+        // You'll need to import com.google.firebase.storage.ktx.component1 and 
+        // com.google.firebase.storage.ktx.component2
         uploadTask.addOnProgressListener { (bytesTransferred, totalByteCount) ->
             val progress = (100.0 * bytesTransferred) / totalByteCount
             Log.d(TAG, "Upload is $progress% done")
@@ -230,6 +232,8 @@ abstract class StorageActivity : AppCompatActivity() {
         uploadTask = storageRef.child("images/${file.lastPathSegment}").putFile(file, metadata)
 
         // Listen for state changes, errors, and completion of the upload.
+        // You'll need to import com.google.firebase.storage.ktx.component1 and 
+        // com.google.firebase.storage.ktx.component2
         uploadTask.addOnProgressListener { (bytesTransferred, totalByteCount) ->
             val progress = (100.0 * bytesTransferred) / totalByteCount
             Log.d(TAG, "Upload is $progress% done")
@@ -430,7 +434,9 @@ abstract class StorageActivity : AppCompatActivity() {
         // [START storage_list_all]
         val storage = Firebase.storage
         val listRef = storage.reference.child("files/uid")
-
+                
+        // You'll need to import com.google.firebase.storage.ktx.component1 and 
+        // com.google.firebase.storage.ktx.component2
         listRef.listAll()
                 .addOnSuccessListener { (items, prefixes) ->
                     prefixes.forEach { prefix ->

--- a/storage/app/src/main/java/com/google/firebase/referencecode/storage/kotlin/StorageActivity.kt
+++ b/storage/app/src/main/java/com/google/firebase/referencecode/storage/kotlin/StorageActivity.kt
@@ -464,6 +464,8 @@ abstract class StorageActivity : AppCompatActivity() {
             listRef.list(100)
         }
 
+        // You'll need to import com.google.firebase.storage.ktx.component1 and 
+        // com.google.firebase.storage.ktx.component2
         listPageTask
                 .addOnSuccessListener { (items, prefixes, pageToken) ->
                     // Process page of results

--- a/storage/app/src/main/java/com/google/firebase/referencecode/storage/kotlin/StorageActivity.kt
+++ b/storage/app/src/main/java/com/google/firebase/referencecode/storage/kotlin/StorageActivity.kt
@@ -23,8 +23,6 @@ import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileInputStream
 
-private const val TAG = "kotlin.StorageActivity"
-
 abstract class StorageActivity : AppCompatActivity() {
 
     // [START storage_field_declaration]
@@ -490,4 +488,8 @@ abstract class StorageActivity : AppCompatActivity() {
         }
     }
     // [END storage_custom_failure_listener]
+
+    companion object {
+        const val TAG = "kotlin.StorageActivity"
+    }
 }

--- a/storage/app/src/main/java/com/google/firebase/referencecode/storage/kotlin/UploadActivity.kt
+++ b/storage/app/src/main/java/com/google/firebase/referencecode/storage/kotlin/UploadActivity.kt
@@ -5,10 +5,10 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.google.firebase.ktx.Firebase
 import com.google.firebase.referencecode.storage.R
-import com.google.firebase.storage.StorageMetadata
 import com.google.firebase.storage.StorageReference
 import com.google.firebase.storage.UploadTask
 import com.google.firebase.storage.ktx.storage
+import com.google.firebase.storage.ktx.storageMetadata
 
 abstract class UploadActivity : AppCompatActivity() {
 
@@ -26,9 +26,7 @@ abstract class UploadActivity : AppCompatActivity() {
         super.onSaveInstanceState(outState)
 
         // If there's an upload in progress, save the reference so you can query it later
-        storageRef?.let {
-            outState.putString("reference", it.toString())
-        }
+        outState.putString("reference", storageRef.toString())
     }
 
     override fun onRestoreInstanceState(savedInstanceState: Bundle) {
@@ -77,7 +75,7 @@ abstract class UploadActivity : AppCompatActivity() {
         // resume the upload task from where it left off when the process died.
         // to do this, pass the sessionUri as the last parameter
         uploadTask = storageRef.putFile(localFile,
-                StorageMetadata.Builder().build(), sessionUri)
+                storageMetadata {  }, sessionUri)
         // [END restore_after_restart]
     }
 }


### PR DESCRIPTION
A few things going on here:

- replace `println()` with `Log.d()` to make it consistent with other snippets.
- use `lateinit var` instead of a nullable `StorageReference`, because the initialization snippet also uses `lateinit var`.
- use the new Kotlin Destructuring Declarations (`storage-ktx:19.2.0`) for `TaskSnapshot` and `ListResult`.
- add missing arguments to lambda functions - some code comments mention variables that are not visible on the docs.
    For example, in the snippet bellow `taskSnapshot` is not visible
    https://github.com/firebase/snippets-android/blob/7695c5ee6589377a40ca8f70c70d6527c5a49897/storage/app/src/main/java/com/google/firebase/referencecode/storage/kotlin/StorageActivity.kt#L149-L154
- replace empty `MetadataBuilder` with its ktx equivalent