### PR TITLE
refactor(firestore): add JvmField annotation to kotlin POJO snippet

### DIFF
--- a/firestore/app/src/main/java/com/google/example/firestore/kotlin/DocSnippets.kt
+++ b/firestore/app/src/main/java/com/google/example/firestore/kotlin/DocSnippets.kt
@@ -234,6 +234,7 @@ abstract class DocSnippets(val db: FirebaseFirestore) {
         val name: String? = null,
         val state: String? = null,
         val country: String? = null,
+        @field:JvmField // use this annotation if your Boolean field is prefixed with 'is'
         val isCapital: Boolean? = null,
         val population: Long? = null,
         val regions: List<String>? = null


### PR DESCRIPTION
As mentioned in StackOverflow answers [1](https://stackoverflow.com/a/52268330/5861618) and [2](https://stackoverflow.com/a/52285505/5861618): when using Kotlin's `data class` in firestore, we need to add the `@field:JvmField` annotation to boolean fields prefixed with 'is', otherwise the Firebase SDK Snapshot parser always returns the default value.

This PR should add that annotation to our Docs, as suggested in [this comment](https://stackoverflow.com/questions/46406376/kotlin-class-does-not-get-its-boolean-value-from-firebase#comment95933719_52268330).