### PR TITLE
refactor(admob): add snippets from quickstart-android

### DIFF
--- a/admob/app/build.gradle
+++ b/admob/app/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation 'androidx.browser:browser:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation "com.google.firebase:firebase-ads:19.6.0"
+    implementation "androidx.constraintlayout:constraintlayout:2.0.4"
 
     // For an optimal experience using AdMob, add the Firebase SDK
     // for Google Analytics. This is recommended, but not required.

--- a/admob/app/build.gradle
+++ b/admob/app/build.gradle
@@ -28,6 +28,11 @@ dependencies {
     implementation "com.google.firebase:firebase-ads:19.6.0"
     implementation "androidx.constraintlayout:constraintlayout:2.0.4"
 
+
+    // [START gradle_play_config]
+    implementation 'com.google.android.gms:play-services-ads:19.6.0'
+    // [END gradle_play_config]
+
     // For an optimal experience using AdMob, add the Firebase SDK
     // for Google Analytics. This is recommended, but not required.
     implementation 'com.google.firebase:firebase-analytics:18.0.0'

--- a/admob/app/build.gradle
+++ b/admob/app/build.gradle
@@ -12,6 +12,7 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        multiDexEnabled true
     }
     buildTypes {
         release {
@@ -27,7 +28,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation "com.google.firebase:firebase-ads:19.6.0"
     implementation "androidx.constraintlayout:constraintlayout:2.0.4"
-
+    implementation "androidx.multidex:multidex:2.0.1"
 
     // [START gradle_play_config]
     implementation 'com.google.android.gms:play-services-ads:19.6.0'

--- a/admob/app/src/main/java/com/google/firebase/example/admob/MainActivity.java
+++ b/admob/app/src/main/java/com/google/firebase/example/admob/MainActivity.java
@@ -1,11 +1,30 @@
 package com.google.firebase.example.admob;
 
+import android.content.Context;
 import android.os.Bundle;
+import android.util.Log;
+import android.view.View;
+import android.widget.Button;
+
 import androidx.appcompat.app.AppCompatActivity;
 
+import com.google.android.gms.ads.AdListener;
+import com.google.android.gms.ads.AdRequest;
+import com.google.android.gms.ads.AdView;
+import com.google.android.gms.ads.InterstitialAd;
+import com.google.android.gms.ads.LoadAdError;
 import com.google.android.gms.ads.MobileAds;
 
+import devrel.firebase.google.com.firebaseoptions.R;
+
 public class MainActivity extends AppCompatActivity {
+
+    private static final String TAG = "MainActivity";
+
+    private AdView mAdView;
+    private InterstitialAd mInterstitialAd;
+    private Button mLoadInterstitialButton;
+    private Context context = this;
 
     // [START ads_on_create]
     @Override
@@ -13,7 +32,103 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         // ...
         MobileAds.initialize(this);
+        // [END ads_on_create]
+
+        // Initialize the Google Mobile Ads SDK
+        MobileAds.initialize(context);
+
+        // [START load_banner_ad]
+        AdRequest adRequest = new AdRequest.Builder().build();
+        mAdView.loadAd(adRequest);
+        // [END load_banner_ad]
+
+        // [START instantiate_interstitial_ad]
+        // Create an InterstitialAd object. This same object can be re-used whenever you want to
+        // show an interstitial.
+        mInterstitialAd = new InterstitialAd(context);
+        mInterstitialAd.setAdUnitId(getString(R.string.interstitial_ad_unit_id));
+        // [END instantiate_interstitial_ad]
+
+        // [START create_interstitial_ad_listener]
+        mInterstitialAd.setAdListener(new AdListener() {
+            @Override
+            public void onAdClosed() {
+                requestNewInterstitial();
+                beginSecondActivity();
+            }
+
+            @Override
+            public void onAdLoaded() {
+                // Ad received, ready to display
+                // ...
+            }
+
+            @Override
+            public void onAdFailedToLoad(LoadAdError loadAdError) {
+                Log.w(TAG, "onAdFailedToLoad:" + loadAdError.getMessage());
+            }
+        });
+        // [END create_interstitial_ad_listener]
+
+        // [START display_interstitial_ad]
+        mLoadInterstitialButton = findViewById(R.id.loadInterstitialButton);
+        mLoadInterstitialButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (mInterstitialAd.isLoaded()) {
+                    mInterstitialAd.show();
+                } else {
+                    beginSecondActivity();
+                }
+            }
+        });
+        // [END display_interstitial_ad]
     }
-    // [END ads_on_create]
+
+    /**
+     * Load a new interstitial ad asynchronously.
+     */
+    // [START request_new_interstitial]
+    private void requestNewInterstitial() {
+        AdRequest adRequest = new AdRequest.Builder()
+                .build();
+
+        mInterstitialAd.loadAd(adRequest);
+    }
+    // [END request_new_interstitial]
+
+    private void beginSecondActivity() { }
+
+    // [START add_lifecycle_methods]
+    /** Called when leaving the activity */
+    @Override
+    public void onPause() {
+        if (mAdView != null) {
+            mAdView.pause();
+        }
+        super.onPause();
+    }
+
+    /** Called when returning to the activity */
+    @Override
+    public void onResume() {
+        super.onResume();
+        if (mAdView != null) {
+            mAdView.resume();
+        }
+        if (!mInterstitialAd.isLoaded()) {
+            requestNewInterstitial();
+        }
+    }
+
+    /** Called before the activity is destroyed */
+    @Override
+    public void onDestroy() {
+        if (mAdView != null) {
+            mAdView.destroy();
+        }
+        super.onDestroy();
+    }
+    // [END add_lifecycle_methods]
 
 }

--- a/admob/app/src/main/java/com/google/firebase/example/admob/MainActivity.java
+++ b/admob/app/src/main/java/com/google/firebase/example/admob/MainActivity.java
@@ -32,23 +32,32 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         // ...
         MobileAds.initialize(this);
-        // [END ads_on_create]
+    }
+    // [END ads_on_create]
+
+    private void loadBannerAd() {
+        // [SNIPPET load_banner_ad]
+        // Load an ad into the AdView.
+        // [START load_banner_ad]
 
         // Initialize the Google Mobile Ads SDK
         MobileAds.initialize(context);
 
-        // [START load_banner_ad]
         AdRequest adRequest = new AdRequest.Builder().build();
         mAdView.loadAd(adRequest);
         // [END load_banner_ad]
+    }
 
+    private void initInterstitialAd() {
         // [START instantiate_interstitial_ad]
         // Create an InterstitialAd object. This same object can be re-used whenever you want to
         // show an interstitial.
         mInterstitialAd = new InterstitialAd(context);
         mInterstitialAd.setAdUnitId(getString(R.string.interstitial_ad_unit_id));
         // [END instantiate_interstitial_ad]
+    }
 
+    private void createInterstitialAdListener() {
         // [START create_interstitial_ad_listener]
         mInterstitialAd.setAdListener(new AdListener() {
             @Override
@@ -69,7 +78,9 @@ public class MainActivity extends AppCompatActivity {
             }
         });
         // [END create_interstitial_ad_listener]
+    }
 
+    private void displayInterstitialAd() {
         // [START display_interstitial_ad]
         mLoadInterstitialButton = findViewById(R.id.loadInterstitialButton);
         mLoadInterstitialButton.setOnClickListener(new View.OnClickListener() {

--- a/admob/app/src/main/java/com/google/firebase/example/admob/kotlin/MainActivity.kt
+++ b/admob/app/src/main/java/com/google/firebase/example/admob/kotlin/MainActivity.kt
@@ -1,16 +1,117 @@
 package com.google.firebase.example.admob.kotlin
 
 import android.os.Bundle
+import android.util.Log
+import android.widget.Button
 import androidx.appcompat.app.AppCompatActivity
+import com.google.android.gms.ads.AdView
+import com.google.android.gms.ads.AdListener
+import com.google.android.gms.ads.AdRequest
+import com.google.android.gms.ads.InterstitialAd
+import com.google.android.gms.ads.LoadAdError
 import com.google.android.gms.ads.MobileAds
+import devrel.firebase.google.com.firebaseoptions.R
 
 class MainActivity : AppCompatActivity() {
+
+    private lateinit var adView: AdView
+    private lateinit var interstitialAd: InterstitialAd
+    private lateinit var loadInterstitialButton: Button
+    private val context = this
 
     // [START ads_on_create]
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         // ...
         MobileAds.initialize(this)
+        // [END ads_on_create]
+
+        // [SNIPPET load_banner_ad]
+        // Load an ad into the AdView.
+        // [START load_banner_ad]
+
+        // Initialize the Google Mobile Ads SDK
+        MobileAds.initialize(context)
+
+        val adRequest = AdRequest.Builder().build()
+
+        adView.loadAd(adRequest)
+        // [END load_banner_ad]
+
+        // [START instantiate_interstitial_ad]
+        // Create an InterstitialAd object. This same object can be re-used whenever you want to
+        // show an interstitial.
+        interstitialAd = InterstitialAd(context)
+        interstitialAd.adUnitId = getString(R.string.interstitial_ad_unit_id)
+        // [END instantiate_interstitial_ad]
+
+        // [START create_interstitial_ad_listener]
+        interstitialAd.adListener = object : AdListener() {
+            override fun onAdClosed() {
+                requestNewInterstitial()
+                beginSecondActivity()
+            }
+
+            override fun onAdLoaded() {
+                // Ad received, ready to display
+                // ...
+            }
+
+            override fun onAdFailedToLoad(error: LoadAdError) {
+                Log.w(TAG, "onAdFailedToLoad: ${error.message}")
+            }
+        }
+        // [END create_interstitial_ad_listener]
+
+        // [START display_interstitial_ad]
+        loadInterstitialButton.setOnClickListener {
+            if (interstitialAd.isLoaded) {
+                interstitialAd.show()
+            } else {
+                beginSecondActivity()
+            }
+        }
+        // [END display_interstitial_ad]
     }
-    // [END ads_on_create]
+
+    /**
+     * Load a new interstitial ad asynchronously.
+     */
+    // [START request_new_interstitial]
+    private fun requestNewInterstitial() {
+        val adRequest = AdRequest.Builder()
+                .build()
+
+        interstitialAd.loadAd(adRequest)
+    }
+    // [END request_new_interstitial]
+
+    private fun beginSecondActivity() { }
+
+    // [START add_lifecycle_methods]
+    /** Called when leaving the activity  */
+    public override fun onPause() {
+        adView.pause()
+        super.onPause()
+    }
+
+    /** Called when returning to the activity  */
+    public override fun onResume() {
+        super.onResume()
+        adView.resume()
+        if (!interstitialAd.isLoaded) {
+            requestNewInterstitial()
+        }
+    }
+
+    /** Called before the activity is destroyed  */
+    public override fun onDestroy() {
+        adView.destroy()
+        super.onDestroy()
+    }
+    // [END add_lifecycle_methods]
+
+    companion object {
+        private const val TAG = "MainActivity"
+    }
 }

--- a/admob/app/src/main/java/com/google/firebase/example/admob/kotlin/MainActivity.kt
+++ b/admob/app/src/main/java/com/google/firebase/example/admob/kotlin/MainActivity.kt
@@ -24,8 +24,10 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         // ...
         MobileAds.initialize(this)
-        // [END ads_on_create]
+    }
+    // [END ads_on_create]
 
+    private fun loadAdBanner() {
         // [SNIPPET load_banner_ad]
         // Load an ad into the AdView.
         // [START load_banner_ad]
@@ -37,14 +39,18 @@ class MainActivity : AppCompatActivity() {
 
         adView.loadAd(adRequest)
         // [END load_banner_ad]
+    }
 
+    private fun initInterstitialAd() {
         // [START instantiate_interstitial_ad]
         // Create an InterstitialAd object. This same object can be re-used whenever you want to
         // show an interstitial.
         interstitialAd = InterstitialAd(context)
         interstitialAd.adUnitId = getString(R.string.interstitial_ad_unit_id)
         // [END instantiate_interstitial_ad]
+    }
 
+    private fun createAdListener() {
         // [START create_interstitial_ad_listener]
         interstitialAd.adListener = object : AdListener() {
             override fun onAdClosed() {
@@ -62,7 +68,9 @@ class MainActivity : AppCompatActivity() {
             }
         }
         // [END create_interstitial_ad_listener]
+    }
 
+    private fun displayInterstitialAd() {
         // [START display_interstitial_ad]
         loadInterstitialButton.setOnClickListener {
             if (interstitialAd.isLoaded) {

--- a/admob/app/src/main/res/layout/activity_main.xml
+++ b/admob/app/src/main/res/layout/activity_main.xml
@@ -1,18 +1,49 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:tools="http://schemas.android.com/tools"
-        android:id="@+id/activity_main"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:paddingLeft="@dimen/activity_horizontal_margin"
-        android:paddingRight="@dimen/activity_horizontal_margin"
-        android:paddingTop="@dimen/activity_vertical_margin"
-        android:paddingBottom="@dimen/activity_vertical_margin"
-        tools:context=".MainActivity">
+<!-- [SNIPPET define_ad_layout]
+Define the namespace and AdView layout that will show the banner.
+[START define_ad_layout] -->
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:ads="http://schemas.android.com/apk/res-auto"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
-    <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Hello World!"/>
-</RelativeLayout>
+    <ImageView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <Button
+        android:id="@+id/loadInterstitialButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/interstitial_button_text"
+        app:layout_constraintBottom_toTopOf="@+id/guideline"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/guideline" />
+
+    <com.google.android.gms.ads.AdView
+        android:id="@+id/adView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_centerHorizontal="true"
+        ads:adSize="BANNER"
+        ads:adUnitId="@string/banner_ad_unit_id"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.5" />
+
+</androidx.constraintlayout.widget.ConstraintLayout><!-- [END define_ad_layout] -->
+

--- a/admob/app/src/main/res/values/strings.xml
+++ b/admob/app/src/main/res/values/strings.xml
@@ -1,3 +1,6 @@
 <resources>
     <string name="app_name">Firebase Options</string>
+    <string name="interstitial_ad_unit_id">ca-app-pub-3940256099942544/1033173712</string>
+    <string name="interstitial_button_text">Show Interstitial Ad</string>
+    <string name="banner_ad_unit_id">ca-app-pub-3940256099942544/6300978111</string>
 </resources>


### PR DESCRIPTION
As discussed in firebase/quickstart-android#1247, we're moving the admob snippets to this repo.

Snippets added in this PR:
<table>
<tr>
<th>Filename</th>
<th>Snippets added</th>
</tr>
<tr>
<td>MainActivity.kt</td>
<td>
ads_on_create,load_banner_ad, instantiate_interstitial_ad, create_interstitial_ad_listener, display_interstitial_ad, request_new_interstitial, add_lifecycle_methods
</td>
</tr>
<tr>
<td>MainActivity.java</td>
<td>ads_on_create,load_banner_ad, instantiate_interstitial_ad, create_interstitial_ad_listener, display_interstitial_ad, request_new_interstitial, add_lifecycle_methods</td>
</tr>
<tr>
<td>activity_main.xml</td>
<td>define_ad_layout</td>
</tr>
<tr>
<td>build.gradle</td>
<td>gradle_play_config</td>
</tr>
</table>


There are snippets in AndroidManifest.xml which were kept in the quickstarts repo.

I also noticed that the `AdListener.onAdFailedToLoad(int)` method used here was deprecated in favor of `AdListener.onAdFailedToLoad(LoadAdError)`, so I replaced it.