### PR TITLE
Fix IP address in EmulatorSuite

### DIFF
--- a/firestore/app/src/main/java/com/google/example/firestore/kotlin/EmulatorSuite.kt
+++ b/firestore/app/src/main/java/com/google/example/firestore/kotlin/EmulatorSuite.kt
@@ -11,7 +11,7 @@ class EmulatorSuite {
         // 10.0.2.2 is the special IP address to connect to the 'localhost' of
         // the host computer from an Android emulator.
         val firestore = Firebase.firestore
-        firestore.useEmulator("10.0.0.2", 8080)
+        firestore.useEmulator("10.0.2.2", 8080)
 
         firestore.firestoreSettings = firestoreSettings {
             isPersistenceEnabled = false


### PR DESCRIPTION
The correct IP address of the host computer from an Android emulator is 10.0.2.2. There was a typo of the code.
https://developer.android.com/studio/run/emulator-networking#networkaddresses