### PR TITLE
refactor(admob): delete unused snippets

### DIFF
--- a/admob/app/build.gradle
+++ b/admob/app/build.gradle
@@ -26,19 +26,19 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.browser:browser:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation "com.google.firebase:firebase-ads:19.7.0"
+    implementation "com.google.firebase:firebase-ads:20.0.0"
     implementation "androidx.constraintlayout:constraintlayout:2.0.4"
     implementation "androidx.multidex:multidex:2.0.1"
 
     // [START gradle_play_config]
-    implementation 'com.google.android.gms:play-services-ads:19.7.0'
+    implementation 'com.google.android.gms:play-services-ads:20.0.0'
     // [END gradle_play_config]
 
     // For an optimal experience using AdMob, add the Firebase SDK
     // for Google Analytics. This is recommended, but not required.
-    implementation 'com.google.firebase:firebase-analytics:18.0.2'
+    implementation 'com.google.firebase:firebase-analytics:18.0.3'
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.31"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.32"
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/admob/app/src/main/java/com/google/firebase/example/admob/MainActivity.java
+++ b/admob/app/src/main/java/com/google/firebase/example/admob/MainActivity.java
@@ -1,30 +1,12 @@
 package com.google.firebase.example.admob;
 
-import android.content.Context;
 import android.os.Bundle;
-import android.util.Log;
-import android.view.View;
-import android.widget.Button;
 
 import androidx.appcompat.app.AppCompatActivity;
 
-import com.google.android.gms.ads.AdListener;
-import com.google.android.gms.ads.AdRequest;
-import com.google.android.gms.ads.AdView;
-import com.google.android.gms.ads.InterstitialAd;
-import com.google.android.gms.ads.LoadAdError;
 import com.google.android.gms.ads.MobileAds;
 
-import devrel.firebase.google.com.firebaseoptions.R;
-
 public class MainActivity extends AppCompatActivity {
-
-    private static final String TAG = "MainActivity";
-
-    private AdView mAdView;
-    private InterstitialAd mInterstitialAd;
-    private Button mLoadInterstitialButton;
-    private Context context = this;
 
     // [START ads_on_create]
     @Override
@@ -34,112 +16,5 @@ public class MainActivity extends AppCompatActivity {
         MobileAds.initialize(this);
     }
     // [END ads_on_create]
-
-    private void loadBannerAd() {
-        // [SNIPPET load_banner_ad]
-        // Load an ad into the AdView.
-        // [START load_banner_ad]
-
-        // Initialize the Google Mobile Ads SDK
-        MobileAds.initialize(context);
-
-        AdRequest adRequest = new AdRequest.Builder().build();
-        mAdView.loadAd(adRequest);
-        // [END load_banner_ad]
-    }
-
-    private void initInterstitialAd() {
-        // [START instantiate_interstitial_ad]
-        // Create an InterstitialAd object. This same object can be re-used whenever you want to
-        // show an interstitial.
-        mInterstitialAd = new InterstitialAd(context);
-        mInterstitialAd.setAdUnitId(getString(R.string.interstitial_ad_unit_id));
-        // [END instantiate_interstitial_ad]
-    }
-
-    private void createInterstitialAdListener() {
-        // [START create_interstitial_ad_listener]
-        mInterstitialAd.setAdListener(new AdListener() {
-            @Override
-            public void onAdClosed() {
-                requestNewInterstitial();
-                beginSecondActivity();
-            }
-
-            @Override
-            public void onAdLoaded() {
-                // Ad received, ready to display
-                // ...
-            }
-
-            @Override
-            public void onAdFailedToLoad(LoadAdError loadAdError) {
-                Log.w(TAG, "onAdFailedToLoad:" + loadAdError.getMessage());
-            }
-        });
-        // [END create_interstitial_ad_listener]
-    }
-
-    private void displayInterstitialAd() {
-        // [START display_interstitial_ad]
-        mLoadInterstitialButton = findViewById(R.id.loadInterstitialButton);
-        mLoadInterstitialButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                if (mInterstitialAd.isLoaded()) {
-                    mInterstitialAd.show();
-                } else {
-                    beginSecondActivity();
-                }
-            }
-        });
-        // [END display_interstitial_ad]
-    }
-
-    /**
-     * Load a new interstitial ad asynchronously.
-     */
-    // [START request_new_interstitial]
-    private void requestNewInterstitial() {
-        AdRequest adRequest = new AdRequest.Builder()
-                .build();
-
-        mInterstitialAd.loadAd(adRequest);
-    }
-    // [END request_new_interstitial]
-
-    private void beginSecondActivity() { }
-
-    // [START add_lifecycle_methods]
-    /** Called when leaving the activity */
-    @Override
-    public void onPause() {
-        if (mAdView != null) {
-            mAdView.pause();
-        }
-        super.onPause();
-    }
-
-    /** Called when returning to the activity */
-    @Override
-    public void onResume() {
-        super.onResume();
-        if (mAdView != null) {
-            mAdView.resume();
-        }
-        if (!mInterstitialAd.isLoaded()) {
-            requestNewInterstitial();
-        }
-    }
-
-    /** Called before the activity is destroyed */
-    @Override
-    public void onDestroy() {
-        if (mAdView != null) {
-            mAdView.destroy();
-        }
-        super.onDestroy();
-    }
-    // [END add_lifecycle_methods]
 
 }

--- a/admob/app/src/main/java/com/google/firebase/example/admob/kotlin/MainActivity.kt
+++ b/admob/app/src/main/java/com/google/firebase/example/admob/kotlin/MainActivity.kt
@@ -1,23 +1,10 @@
 package com.google.firebase.example.admob.kotlin
 
 import android.os.Bundle
-import android.util.Log
-import android.widget.Button
 import androidx.appcompat.app.AppCompatActivity
-import com.google.android.gms.ads.AdView
-import com.google.android.gms.ads.AdListener
-import com.google.android.gms.ads.AdRequest
-import com.google.android.gms.ads.InterstitialAd
-import com.google.android.gms.ads.LoadAdError
 import com.google.android.gms.ads.MobileAds
-import devrel.firebase.google.com.firebaseoptions.R
 
 class MainActivity : AppCompatActivity() {
-
-    private lateinit var adView: AdView
-    private lateinit var interstitialAd: InterstitialAd
-    private lateinit var loadInterstitialButton: Button
-    private val context = this
 
     // [START ads_on_create]
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -26,100 +13,4 @@ class MainActivity : AppCompatActivity() {
         MobileAds.initialize(this)
     }
     // [END ads_on_create]
-
-    private fun loadAdBanner() {
-        // [SNIPPET load_banner_ad]
-        // Load an ad into the AdView.
-        // [START load_banner_ad]
-
-        // Initialize the Google Mobile Ads SDK
-        MobileAds.initialize(context)
-
-        val adRequest = AdRequest.Builder().build()
-
-        adView.loadAd(adRequest)
-        // [END load_banner_ad]
-    }
-
-    private fun initInterstitialAd() {
-        // [START instantiate_interstitial_ad]
-        // Create an InterstitialAd object. This same object can be re-used whenever you want to
-        // show an interstitial.
-        interstitialAd = InterstitialAd(context)
-        interstitialAd.adUnitId = getString(R.string.interstitial_ad_unit_id)
-        // [END instantiate_interstitial_ad]
-    }
-
-    private fun createAdListener() {
-        // [START create_interstitial_ad_listener]
-        interstitialAd.adListener = object : AdListener() {
-            override fun onAdClosed() {
-                requestNewInterstitial()
-                beginSecondActivity()
-            }
-
-            override fun onAdLoaded() {
-                // Ad received, ready to display
-                // ...
-            }
-
-            override fun onAdFailedToLoad(error: LoadAdError) {
-                Log.w(TAG, "onAdFailedToLoad: ${error.message}")
-            }
-        }
-        // [END create_interstitial_ad_listener]
-    }
-
-    private fun displayInterstitialAd() {
-        // [START display_interstitial_ad]
-        loadInterstitialButton.setOnClickListener {
-            if (interstitialAd.isLoaded) {
-                interstitialAd.show()
-            } else {
-                beginSecondActivity()
-            }
-        }
-        // [END display_interstitial_ad]
-    }
-
-    /**
-     * Load a new interstitial ad asynchronously.
-     */
-    // [START request_new_interstitial]
-    private fun requestNewInterstitial() {
-        val adRequest = AdRequest.Builder()
-                .build()
-
-        interstitialAd.loadAd(adRequest)
-    }
-    // [END request_new_interstitial]
-
-    private fun beginSecondActivity() { }
-
-    // [START add_lifecycle_methods]
-    /** Called when leaving the activity  */
-    public override fun onPause() {
-        adView.pause()
-        super.onPause()
-    }
-
-    /** Called when returning to the activity  */
-    public override fun onResume() {
-        super.onResume()
-        adView.resume()
-        if (!interstitialAd.isLoaded) {
-            requestNewInterstitial()
-        }
-    }
-
-    /** Called before the activity is destroyed  */
-    public override fun onDestroy() {
-        adView.destroy()
-        super.onDestroy()
-    }
-    // [END add_lifecycle_methods]
-
-    companion object {
-        private const val TAG = "MainActivity"
-    }
 }

--- a/admob/build.gradle
+++ b/admob/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.31"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
     }
 }
 

--- a/analytics/app/build.gradle
+++ b/analytics/app/build.gradle
@@ -24,10 +24,10 @@ android {
 dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.31"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.32"
 
-    implementation "com.google.firebase:firebase-analytics:18.0.2"
-    implementation "com.google.firebase:firebase-analytics-ktx:18.0.2"
+    implementation "com.google.firebase:firebase-analytics:18.0.3"
+    implementation "com.google.firebase:firebase-analytics-ktx:18.0.3"
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/analytics/build.gradle
+++ b/analytics/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.31"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
     }
 }
 

--- a/appindexing/app/build.gradle
+++ b/appindexing/app/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation "com.google.firebase:firebase-appindexing:19.2.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.31"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.32"
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 }
 

--- a/appindexing/build.gradle
+++ b/appindexing/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.31"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
     }
 }
 

--- a/auth/app/build.gradle
+++ b/auth/app/build.gradle
@@ -22,7 +22,7 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.31"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.32"
     
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.31"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.31"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
     }
 }
 

--- a/crashlytics/app/build.gradle
+++ b/crashlytics/app/build.gradle
@@ -25,14 +25,14 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'
 
-    implementation 'com.google.firebase:firebase-crashlytics:17.3.1'
-    implementation 'com.google.firebase:firebase-crashlytics-ktx:17.3.1'
+    implementation 'com.google.firebase:firebase-crashlytics:17.4.1'
+    implementation 'com.google.firebase:firebase-crashlytics-ktx:17.4.1'
 
     // For an optimal experience using Crashlytics, add the Firebase SDK
     // for Google Analytics. This is recommended, but not required.
-    implementation 'com.google.firebase:firebase-analytics:18.0.2'
+    implementation 'com.google.firebase:firebase-analytics:18.0.3'
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.31"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.32"
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/crashlytics/build.gradle
+++ b/crashlytics/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.31"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
     }
 }
 

--- a/database/app/build.gradle
+++ b/database/app/build.gradle
@@ -29,8 +29,8 @@ android {
 dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation "com.google.firebase:firebase-database-ktx:19.6.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.31"
+    implementation "com.google.firebase:firebase-database-ktx:19.7.0"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.32"
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/database/build.gradle
+++ b/database/build.gradle
@@ -7,9 +7,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.31"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
     }
 }
 

--- a/dl-invites/app/build.gradle
+++ b/dl-invites/app/build.gradle
@@ -29,11 +29,11 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.cardview:cardview:1.0.0'
-    implementation 'androidx.recyclerview:recyclerview:1.1.0'
+    implementation 'androidx.recyclerview:recyclerview:1.2.0'
     implementation 'com.google.firebase:firebase-dynamic-links:19.1.1'
 
     implementation 'com.google.android.material:material:1.3.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.31"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.32"
 }

--- a/dl-invites/build.gradle
+++ b/dl-invites/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.31"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
     }
 }
 

--- a/dynamic-links/app/build.gradle
+++ b/dynamic-links/app/build.gradle
@@ -24,15 +24,15 @@ android {
 dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation "com.google.firebase:firebase-auth-ktx:20.0.3"
+    implementation "com.google.firebase:firebase-auth-ktx:20.0.4"
     implementation "com.google.firebase:firebase-invites:17.0.0"
     implementation "com.google.firebase:firebase-dynamic-links-ktx:19.1.1"
 
     // For an optimal experience using Dynamic Links, add the Firebase SDK
     // for Google Analytics. This is recommended, but not required.
-    implementation 'com.google.firebase:firebase-analytics:18.0.2'
+    implementation 'com.google.firebase:firebase-analytics:18.0.3'
 
-    implementation "com.google.firebase:firebase-database-ktx:19.6.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.31"
+    implementation "com.google.firebase:firebase-database-ktx:19.7.0"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.32"
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 }

--- a/dynamic-links/build.gradle
+++ b/dynamic-links/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.31"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
     }
 }
 

--- a/firebaseoptions/app/build.gradle
+++ b/firebaseoptions/app/build.gradle
@@ -25,8 +25,8 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation "com.google.firebase:firebase-common-ktx:19.5.0"
-    implementation "com.google.firebase:firebase-database-ktx:19.6.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.31"
+    implementation "com.google.firebase:firebase-database-ktx:19.7.0"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.32"
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/firebaseoptions/build.gradle
+++ b/firebaseoptions/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.31"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
     }
 }
 

--- a/firestore/app/build.gradle
+++ b/firestore/app/build.gradle
@@ -40,13 +40,13 @@ dependencies {
     implementation 'androidx.multidex:multidex:2.0.1'
 
     // Firestore
-    implementation "com.google.firebase:firebase-firestore-ktx:22.1.1"
+    implementation "com.google.firebase:firebase-firestore-ktx:22.1.2"
 
     // Firebase / Play Services
-    implementation "com.google.firebase:firebase-auth:20.0.3"
+    implementation "com.google.firebase:firebase-auth:20.0.4"
     implementation "com.google.android.gms:play-services-auth:19.0.0"
     implementation "com.google.firebase:firebase-functions-ktx:19.2.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.31"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.32"
 
     // GeoFire (for Geoqueries solution)
     implementation "com.firebase:geofire-android-common:3.1.0"

--- a/firestore/build.gradle
+++ b/firestore/build.gradle
@@ -7,9 +7,9 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.31"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
     }
 }
 

--- a/functions/app/build.gradle
+++ b/functions/app/build.gradle
@@ -24,7 +24,7 @@ android {
 dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.31"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.32"
 
     implementation "com.google.firebase:firebase-functions-ktx:19.2.0"
 }

--- a/functions/build.gradle
+++ b/functions/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.31"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
     }
 }
 

--- a/inappmessaging/app/build.gradle
+++ b/inappmessaging/app/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation "com.google.firebase:firebase-inappmessaging-display-ktx:19.1.5"
 
     // The Firebase SDK for Google Analytics is required to use In-App Messaging.
-    implementation 'com.google.firebase:firebase-analytics:18.0.2'
+    implementation 'com.google.firebase:firebase-analytics:18.0.3'
     
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.31"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.32"
 }

--- a/inappmessaging/build.gradle
+++ b/inappmessaging/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.31"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
     }
 }
 

--- a/installations/app/build.gradle
+++ b/installations/app/build.gradle
@@ -25,7 +25,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.4.31"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.4.32"
     implementation 'androidx.core:core-ktx:1.3.2'
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'

--- a/installations/build.gradle
+++ b/installations/build.gradle
@@ -5,9 +5,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.1.2"
+        classpath "com.android.tools.build:gradle:4.1.3"
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.31"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/messaging/app/build.gradle
+++ b/messaging/app/build.gradle
@@ -28,10 +28,10 @@ dependencies {
 
     // For an optimal experience using FCM, add the Firebase SDK
     // for Google Analytics. This is recommended, but not required.
-    implementation 'com.google.firebase:firebase-analytics:18.0.2'
+    implementation 'com.google.firebase:firebase-analytics:18.0.3'
 
     implementation "com.google.android.gms:play-services-auth:19.0.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.31"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.32"
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/messaging/build.gradle
+++ b/messaging/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.31"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
     }
 }
 

--- a/ml-functions/build.gradle
+++ b/ml-functions/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.31"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
     }
 }
 

--- a/mlkit/app/build.gradle
+++ b/mlkit/app/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     implementation 'com.google.android.gms:play-services-vision:20.1.3'
     implementation 'com.google.android.gms:play-services-vision-common:19.1.3'
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.31"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.32"
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/mlkit/build.gradle
+++ b/mlkit/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.31"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
     }
 }
 

--- a/perf/app/build.gradle
+++ b/perf/app/build.gradle
@@ -26,5 +26,5 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation "com.google.firebase:firebase-config-ktx:20.0.4"
     implementation "com.google.firebase:firebase-perf-ktx:19.1.1"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.31"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.32"
 }

--- a/perf/build.gradle
+++ b/perf/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.31"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
     }
 }
 

--- a/predictions/app/build.gradle
+++ b/predictions/app/build.gradle
@@ -27,8 +27,8 @@ dependencies {
     implementation 'androidx.browser:browser:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'
 
-    implementation "com.google.firebase:firebase-ads:19.7.0"
-    implementation "com.google.firebase:firebase-analytics:18.0.2"
+    implementation "com.google.firebase:firebase-ads:20.0.0"
+    implementation "com.google.firebase:firebase-analytics:18.0.3"
     implementation "com.google.firebase:firebase-config-ktx:20.0.4"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.31"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.32"
 }

--- a/predictions/build.gradle
+++ b/predictions/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.31"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
     }
 }
 

--- a/storage/app/build.gradle
+++ b/storage/app/build.gradle
@@ -24,14 +24,14 @@ android {
 dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation "com.google.firebase:firebase-storage-ktx:19.2.1"
+    implementation "com.google.firebase:firebase-storage-ktx:19.2.2"
 
     implementation 'com.firebaseui:firebase-ui-storage:7.1.1'
     implementation 'com.github.bumptech.glide:glide:4.12.0'
     annotationProcessor 'com.github.bumptech.glide:compiler:4.12.0'
     kapt 'com.github.bumptech.glide:compiler:4.12.0'
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.31"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.32"
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 }
 

--- a/storage/build.gradle
+++ b/storage/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.31"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
     }
 }
 

--- a/tasks/app/build.gradle
+++ b/tasks/app/build.gradle
@@ -25,6 +25,6 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'
 
-    implementation "com.google.firebase:firebase-auth-ktx:20.0.3"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.31"
+    implementation "com.google.firebase:firebase-auth-ktx:20.0.4"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.32"
 }

--- a/tasks/build.gradle
+++ b/tasks/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.31"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
     }
 }
 

--- a/test-lab/app/build.gradle
+++ b/test-lab/app/build.gradle
@@ -30,8 +30,8 @@ repositories {
 dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation "com.google.firebase:firebase-iid:21.0.1"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.31"
+    implementation "com.google.firebase:firebase-iid:21.1.0"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.32"
 
     implementation(name:'cloudtestingscreenshotter_lib', ext:'aar')
 

--- a/test-lab/build.gradle
+++ b/test-lab/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.31"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
     }
 }
 


### PR DESCRIPTION
The build is failing in #285 due to AdMob Breaking Changes.
I was going to upgrade this code to the [new admob v20.0.0](https://developers.google.com/admob/android/migration), but then I noticed that most of it is not even shown on [our docs](https://firebase.google.com/docs/admob/android/quick-start#set-up-app-in-admob). Maybe it's time to clean it up?