### PR TITLE
upgrade to AGP 4.2, update dependencies and remove kotlin stdlib

### DIFF
--- a/admob/app/build.gradle
+++ b/admob/app/build.gradle
@@ -37,8 +37,6 @@ dependencies {
     // For an optimal experience using AdMob, add the Firebase SDK
     // for Google Analytics. This is recommended, but not required.
     implementation 'com.google.firebase:firebase-analytics:18.0.3'
-
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0"
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/admob/app/build.gradle
+++ b/admob/app/build.gradle
@@ -26,19 +26,19 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.browser:browser:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation "com.google.firebase:firebase-ads:20.0.0"
+    implementation "com.google.firebase:firebase-ads:20.1.0"
     implementation "androidx.constraintlayout:constraintlayout:2.0.4"
     implementation "androidx.multidex:multidex:2.0.1"
 
     // [START gradle_play_config]
-    implementation 'com.google.android.gms:play-services-ads:20.0.0'
+    implementation 'com.google.android.gms:play-services-ads:20.1.0'
     // [END gradle_play_config]
 
     // For an optimal experience using AdMob, add the Firebase SDK
     // for Google Analytics. This is recommended, but not required.
     implementation 'com.google.firebase:firebase-analytics:18.0.3'
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.32"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0"
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/admob/build.gradle
+++ b/admob/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0"
     }
 }
 

--- a/analytics/app/build.gradle
+++ b/analytics/app/build.gradle
@@ -24,7 +24,6 @@ android {
 dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0"
 
     implementation "com.google.firebase:firebase-analytics:18.0.3"
     implementation "com.google.firebase:firebase-analytics-ktx:18.0.3"

--- a/analytics/app/build.gradle
+++ b/analytics/app/build.gradle
@@ -24,7 +24,7 @@ android {
 dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.32"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0"
 
     implementation "com.google.firebase:firebase-analytics:18.0.3"
     implementation "com.google.firebase:firebase-analytics-ktx:18.0.3"

--- a/analytics/build.gradle
+++ b/analytics/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0"
     }
 }
 

--- a/appindexing/app/build.gradle
+++ b/appindexing/app/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation "com.google.firebase:firebase-appindexing:19.2.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.32"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0"
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 }
 

--- a/appindexing/app/build.gradle
+++ b/appindexing/app/build.gradle
@@ -25,7 +25,6 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation "com.google.firebase:firebase-appindexing:19.2.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0"
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 }
 

--- a/appindexing/build.gradle
+++ b/appindexing/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0"
     }
 }
 

--- a/auth/app/build.gradle
+++ b/auth/app/build.gradle
@@ -22,7 +22,7 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.32"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0"
     
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'

--- a/auth/app/build.gradle
+++ b/auth/app/build.gradle
@@ -22,8 +22,6 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0"
-    
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.browser:browser:1.0.0'

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0"
     }
 }
 

--- a/crashlytics/app/build.gradle
+++ b/crashlytics/app/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     // for Google Analytics. This is recommended, but not required.
     implementation 'com.google.firebase:firebase-analytics:18.0.3'
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.32"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0"
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/crashlytics/app/build.gradle
+++ b/crashlytics/app/build.gradle
@@ -31,8 +31,6 @@ dependencies {
     // For an optimal experience using Crashlytics, add the Firebase SDK
     // for Google Analytics. This is recommended, but not required.
     implementation 'com.google.firebase:firebase-analytics:18.0.3'
-
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0"
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/crashlytics/build.gradle
+++ b/crashlytics/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0"
     }
 }
 

--- a/database/app/build.gradle
+++ b/database/app/build.gradle
@@ -30,7 +30,6 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation "com.google.firebase:firebase-database-ktx:19.7.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0"
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/database/app/build.gradle
+++ b/database/app/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation "com.google.firebase:firebase-database-ktx:19.7.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.32"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0"
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/database/build.gradle
+++ b/database/build.gradle
@@ -7,9 +7,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0"
     }
 }
 

--- a/dl-invites/app/build.gradle
+++ b/dl-invites/app/build.gradle
@@ -34,6 +34,4 @@ dependencies {
 
     implementation 'com.google.android.material:material:1.3.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
-
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0"
 }

--- a/dl-invites/app/build.gradle
+++ b/dl-invites/app/build.gradle
@@ -35,5 +35,5 @@ dependencies {
     implementation 'com.google.android.material:material:1.3.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.32"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0"
 }

--- a/dl-invites/build.gradle
+++ b/dl-invites/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0"
     }
 }
 

--- a/dynamic-links/app/build.gradle
+++ b/dynamic-links/app/build.gradle
@@ -33,6 +33,5 @@ dependencies {
     implementation 'com.google.firebase:firebase-analytics:18.0.3'
 
     implementation "com.google.firebase:firebase-database-ktx:19.7.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0"
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 }

--- a/dynamic-links/app/build.gradle
+++ b/dynamic-links/app/build.gradle
@@ -33,6 +33,6 @@ dependencies {
     implementation 'com.google.firebase:firebase-analytics:18.0.3'
 
     implementation "com.google.firebase:firebase-database-ktx:19.7.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.32"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0"
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 }

--- a/dynamic-links/build.gradle
+++ b/dynamic-links/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0"
     }
 }
 

--- a/firebaseoptions/app/build.gradle
+++ b/firebaseoptions/app/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation "com.google.firebase:firebase-common-ktx:19.5.0"
     implementation "com.google.firebase:firebase-database-ktx:19.7.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.32"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0"
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/firebaseoptions/app/build.gradle
+++ b/firebaseoptions/app/build.gradle
@@ -26,7 +26,6 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation "com.google.firebase:firebase-common-ktx:19.5.0"
     implementation "com.google.firebase:firebase-database-ktx:19.7.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0"
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/firebaseoptions/build.gradle
+++ b/firebaseoptions/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0"
     }
 }
 

--- a/firestore/app/build.gradle
+++ b/firestore/app/build.gradle
@@ -46,7 +46,6 @@ dependencies {
     implementation "com.google.firebase:firebase-auth:20.0.4"
     implementation "com.google.android.gms:play-services-auth:19.0.0"
     implementation "com.google.firebase:firebase-functions-ktx:19.2.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0"
 
     // GeoFire (for Geoqueries solution)
     implementation "com.firebase:geofire-android-common:3.1.0"

--- a/firestore/app/build.gradle
+++ b/firestore/app/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     implementation "com.google.firebase:firebase-auth:20.0.4"
     implementation "com.google.android.gms:play-services-auth:19.0.0"
     implementation "com.google.firebase:firebase-functions-ktx:19.2.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.32"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0"
 
     // GeoFire (for Geoqueries solution)
     implementation "com.firebase:geofire-android-common:3.1.0"

--- a/firestore/build.gradle
+++ b/firestore/build.gradle
@@ -7,9 +7,9 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0"
     }
 }
 

--- a/functions/app/build.gradle
+++ b/functions/app/build.gradle
@@ -24,7 +24,6 @@ android {
 dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0"
 
     implementation "com.google.firebase:firebase-functions-ktx:19.2.0"
 }

--- a/functions/app/build.gradle
+++ b/functions/app/build.gradle
@@ -24,7 +24,7 @@ android {
 dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.32"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0"
 
     implementation "com.google.firebase:firebase-functions-ktx:19.2.0"
 }

--- a/functions/build.gradle
+++ b/functions/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0"
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/inappmessaging/app/build.gradle
+++ b/inappmessaging/app/build.gradle
@@ -33,6 +33,4 @@ dependencies {
 
     // The Firebase SDK for Google Analytics is required to use In-App Messaging.
     implementation 'com.google.firebase:firebase-analytics:18.0.3'
-    
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0"
 }

--- a/inappmessaging/app/build.gradle
+++ b/inappmessaging/app/build.gradle
@@ -34,5 +34,5 @@ dependencies {
     // The Firebase SDK for Google Analytics is required to use In-App Messaging.
     implementation 'com.google.firebase:firebase-analytics:18.0.3'
     
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.32"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0"
 }

--- a/inappmessaging/build.gradle
+++ b/inappmessaging/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0"
     }
 }
 

--- a/installations/app/build.gradle
+++ b/installations/app/build.gradle
@@ -25,7 +25,6 @@ android {
 
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.5.0"
     implementation 'androidx.core:core-ktx:1.3.2'
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'

--- a/installations/app/build.gradle
+++ b/installations/app/build.gradle
@@ -25,7 +25,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.4.32"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.5.0"
     implementation 'androidx.core:core-ktx:1.3.2'
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'

--- a/installations/build.gradle
+++ b/installations/build.gradle
@@ -5,9 +5,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.1.3"
+        classpath "com.android.tools.build:gradle:4.2.0"
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/messaging/app/build.gradle
+++ b/messaging/app/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-analytics:18.0.3'
 
     implementation "com.google.android.gms:play-services-auth:19.0.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.32"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0"
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/messaging/app/build.gradle
+++ b/messaging/app/build.gradle
@@ -31,7 +31,6 @@ dependencies {
     implementation 'com.google.firebase:firebase-analytics:18.0.3'
 
     implementation "com.google.android.gms:play-services-auth:19.0.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0"
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/messaging/build.gradle
+++ b/messaging/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0"
     }
 }
 

--- a/ml-functions/build.gradle
+++ b/ml-functions/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0"
     }
 }
 

--- a/mlkit/app/build.gradle
+++ b/mlkit/app/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     implementation 'com.google.android.gms:play-services-vision:20.1.3'
     implementation 'com.google.android.gms:play-services-vision-common:19.1.3'
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.32"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0"
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/mlkit/app/build.gradle
+++ b/mlkit/app/build.gradle
@@ -41,8 +41,6 @@ dependencies {
     // Image Labeling model.
     implementation 'com.google.android.gms:play-services-vision:20.1.3'
     implementation 'com.google.android.gms:play-services-vision-common:19.1.3'
-
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0"
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/mlkit/build.gradle
+++ b/mlkit/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0"
     }
 }
 

--- a/perf/app/build.gradle
+++ b/perf/app/build.gradle
@@ -26,5 +26,5 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation "com.google.firebase:firebase-config-ktx:20.0.4"
     implementation "com.google.firebase:firebase-perf-ktx:19.1.1"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.32"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0"
 }

--- a/perf/app/build.gradle
+++ b/perf/app/build.gradle
@@ -26,5 +26,4 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation "com.google.firebase:firebase-config-ktx:20.0.4"
     implementation "com.google.firebase:firebase-perf-ktx:19.1.1"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0"
 }

--- a/perf/build.gradle
+++ b/perf/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0"
     }
 }
 

--- a/predictions/app/build.gradle
+++ b/predictions/app/build.gradle
@@ -30,5 +30,4 @@ dependencies {
     implementation "com.google.firebase:firebase-ads:20.1.0"
     implementation "com.google.firebase:firebase-analytics:18.0.3"
     implementation "com.google.firebase:firebase-config-ktx:20.0.4"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0"
 }

--- a/predictions/app/build.gradle
+++ b/predictions/app/build.gradle
@@ -27,8 +27,8 @@ dependencies {
     implementation 'androidx.browser:browser:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'
 
-    implementation "com.google.firebase:firebase-ads:20.0.0"
+    implementation "com.google.firebase:firebase-ads:20.1.0"
     implementation "com.google.firebase:firebase-analytics:18.0.3"
     implementation "com.google.firebase:firebase-config-ktx:20.0.4"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.32"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0"
 }

--- a/predictions/build.gradle
+++ b/predictions/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0"
     }
 }
 

--- a/storage/app/build.gradle
+++ b/storage/app/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     annotationProcessor 'com.github.bumptech.glide:compiler:4.12.0'
     kapt 'com.github.bumptech.glide:compiler:4.12.0'
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.32"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0"
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 }
 

--- a/storage/app/build.gradle
+++ b/storage/app/build.gradle
@@ -31,7 +31,6 @@ dependencies {
     annotationProcessor 'com.github.bumptech.glide:compiler:4.12.0'
     kapt 'com.github.bumptech.glide:compiler:4.12.0'
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0"
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 }
 

--- a/storage/build.gradle
+++ b/storage/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0"
     }
 }
 

--- a/tasks/app/build.gradle
+++ b/tasks/app/build.gradle
@@ -26,5 +26,5 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
 
     implementation "com.google.firebase:firebase-auth-ktx:20.0.4"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.32"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0"
 }

--- a/tasks/app/build.gradle
+++ b/tasks/app/build.gradle
@@ -26,5 +26,4 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
 
     implementation "com.google.firebase:firebase-auth-ktx:20.0.4"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0"
 }

--- a/tasks/build.gradle
+++ b/tasks/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0"
     }
 }
 

--- a/test-lab/app/build.gradle
+++ b/test-lab/app/build.gradle
@@ -31,7 +31,6 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation "com.google.firebase:firebase-iid:21.1.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0"
 
     implementation(name:'cloudtestingscreenshotter_lib', ext:'aar')
 

--- a/test-lab/app/build.gradle
+++ b/test-lab/app/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation "com.google.firebase:firebase-iid:21.1.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.32"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.0"
 
     implementation(name:'cloudtestingscreenshotter_lib', ext:'aar')
 

--- a/test-lab/build.gradle
+++ b/test-lab/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0"
     }
 }
 


### PR DESCRIPTION
This PR should:
- Upgrade Android Gradle Plugin to v4.2 (by @dpebot)
- Update gradle from 6.5.1 to 6.7.1 (minimum supported by AGP 4.2)
- Remove Kotlin stdlib dependency - this is unrelated to the 4.2 upgrade, but since stdlib is now automatically added by the Kotlin plugin, I thought we could remove it. This way dpebot has less files to update when a new Kotlin version is out.