### PR TITLE
Fix incorrect emulator host IP address

### DIFF
--- a/functions/app/src/main/java/devrel/firebase/google/com/functions/MainActivity.java
+++ b/functions/app/src/main/java/devrel/firebase/google/com/functions/MainActivity.java
@@ -26,7 +26,7 @@ public class MainActivity extends AppCompatActivity {
         // 10.0.2.2 is the special IP address to connect to the 'localhost' of
         // the host computer from an Android emulator.
         FirebaseFunctions functions = FirebaseFunctions.getInstance();
-        functions.useEmulator("10.0.2.2.", 5001);
+        functions.useEmulator("10.0.2.2", 5001);
         // [END functions_emulator_connect]
     }
 

--- a/functions/app/src/main/java/devrel/firebase/google/com/functions/kotlin/MainActivity.kt
+++ b/functions/app/src/main/java/devrel/firebase/google/com/functions/kotlin/MainActivity.kt
@@ -12,7 +12,7 @@ class MainActivity : AppCompatActivity() {
         // 10.0.2.2 is the special IP address to connect to the 'localhost' of
         // the host computer from an Android emulator.
         val functions = Firebase.functions
-        functions.useEmulator("10.0.2.2.", 5001)
+        functions.useEmulator("10.0.2.2", 5001)
         // [END functions_emulator_connect]
     }
 }


### PR DESCRIPTION
Fix the incorrect emulator IP in functions emulator sample codes.

Previous code caused the below error.
```
Caused by: java.net.UnknownHostException: Unable to resolve host "10.0.2.2.": No address associated with hostname
```