### PR TITLE
refactor: update to AGP7 and Java 11

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: set up JDK 1.8
+    - name: set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - name: Check Snippets
       run: python scripts/checksnippets.py
     - name: Install NDK

--- a/admob/app/build.gradle
+++ b/admob/app/build.gradle
@@ -24,7 +24,7 @@ android {
 dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.browser:browser:1.0.0'
-    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation "com.google.firebase:firebase-ads:20.2.0"
     implementation "androidx.constraintlayout:constraintlayout:2.0.4"
     implementation "androidx.multidex:multidex:2.0.1"

--- a/admob/build.gradle
+++ b/admob/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.0.0'
         classpath 'com.google.gms:google-services:4.3.8'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21"
     }

--- a/analytics/app/build.gradle
+++ b/analytics/app/build.gradle
@@ -22,7 +22,7 @@ android {
 
 dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
 
     implementation "com.google.firebase:firebase-analytics:19.0.0"
     implementation "com.google.firebase:firebase-analytics-ktx:19.0.0"

--- a/analytics/build.gradle
+++ b/analytics/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.0.0'
         classpath 'com.google.gms:google-services:4.3.8'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21"
     }

--- a/appcheck/build.gradle
+++ b/appcheck/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.2.2"
+        classpath "com.android.tools.build:gradle:7.0.0"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.google.gms:google-services:4.3.8'
 

--- a/appindexing/app/build.gradle
+++ b/appindexing/app/build.gradle
@@ -22,7 +22,7 @@ android {
 
 dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation "com.google.firebase:firebase-appindexing:20.0.0"
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 }

--- a/appindexing/build.gradle
+++ b/appindexing/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.0.0'
         classpath 'com.google.gms:google-services:4.3.8'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21"
     }

--- a/auth/app/build.gradle
+++ b/auth/app/build.gradle
@@ -22,12 +22,12 @@ android {
 
 dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'androidx.browser:browser:1.0.0'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
     implementation 'com.google.android.material:material:1.4.0'
-    implementation 'androidx.activity:activity:1.2.3'
+    implementation 'androidx.activity:activity:1.3.0'
 
     implementation "com.google.firebase:firebase-auth-ktx:21.0.1"
     

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.0.0'
         classpath 'com.google.gms:google-services:4.3.8'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.0.0'
         classpath 'com.google.gms:google-services:4.3.8'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21"
     }

--- a/crashlytics/app/build.gradle
+++ b/crashlytics/app/build.gradle
@@ -22,10 +22,10 @@ android {
 
 dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
 
-    implementation 'com.google.firebase:firebase-crashlytics:18.1.0'
-    implementation 'com.google.firebase:firebase-crashlytics-ktx:18.1.0'
+    implementation 'com.google.firebase:firebase-crashlytics:18.2.0'
+    implementation 'com.google.firebase:firebase-crashlytics-ktx:18.2.0'
 
     // For an optimal experience using Crashlytics, add the Firebase SDK
     // for Google Analytics. This is recommended, but not required.

--- a/crashlytics/build.gradle
+++ b/crashlytics/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.0.0'
         classpath 'com.google.gms:google-services:4.3.8'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21"
     }

--- a/database/app/build.gradle
+++ b/database/app/build.gradle
@@ -27,8 +27,8 @@ android {
 
 dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.appcompat:appcompat:1.3.0'
-    implementation "com.google.firebase:firebase-database-ktx:20.0.0"
+    implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation "com.google.firebase:firebase-database-ktx:20.0.1"
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/database/build.gradle
+++ b/database/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.0.0'
         classpath 'com.google.gms:google-services:4.3.8'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21"
     }

--- a/dl-invites/app/build.gradle
+++ b/dl-invites/app/build.gradle
@@ -22,10 +22,10 @@ android {
 
 dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
-    implementation 'com.google.firebase:firebase-dynamic-links:20.1.0'
+    implementation 'com.google.firebase:firebase-dynamic-links:20.1.1'
 
     implementation 'com.google.android.material:material:1.4.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'

--- a/dl-invites/build.gradle
+++ b/dl-invites/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.0.0'
         classpath 'com.google.gms:google-services:4.3.8'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21"
     }

--- a/dynamic-links/app/build.gradle
+++ b/dynamic-links/app/build.gradle
@@ -22,15 +22,15 @@ android {
 
 dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation "com.google.firebase:firebase-auth-ktx:21.0.1"
     implementation "com.google.firebase:firebase-invites:17.0.0"
-    implementation "com.google.firebase:firebase-dynamic-links-ktx:20.1.0"
+    implementation "com.google.firebase:firebase-dynamic-links-ktx:20.1.1"
 
     // For an optimal experience using Dynamic Links, add the Firebase SDK
     // for Google Analytics. This is recommended, but not required.
     implementation 'com.google.firebase:firebase-analytics:19.0.0'
 
-    implementation "com.google.firebase:firebase-database-ktx:20.0.0"
+    implementation "com.google.firebase:firebase-database-ktx:20.0.1"
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 }

--- a/dynamic-links/build.gradle
+++ b/dynamic-links/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.0.0'
         classpath 'com.google.gms:google-services:4.3.8'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21"
     }

--- a/firebaseoptions/app/build.gradle
+++ b/firebaseoptions/app/build.gradle
@@ -22,9 +22,9 @@ android {
 
 dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation "com.google.firebase:firebase-common-ktx:20.0.0"
-    implementation "com.google.firebase:firebase-database-ktx:20.0.0"
+    implementation "com.google.firebase:firebase-database-ktx:20.0.1"
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/firebaseoptions/build.gradle
+++ b/firebaseoptions/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.0.0'
         classpath 'com.google.gms:google-services:4.3.8'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21"
     }

--- a/firestore/app/build.gradle
+++ b/firestore/app/build.gradle
@@ -34,16 +34,16 @@ repositories {
 
 dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
     implementation 'androidx.multidex:multidex:2.0.1'
 
     // Firestore
-    implementation "com.google.firebase:firebase-firestore-ktx:23.0.2"
+    implementation "com.google.firebase:firebase-firestore-ktx:23.0.3"
 
     // Firebase / Play Services
     implementation "com.google.firebase:firebase-auth:21.0.1"
-    implementation "com.google.android.gms:play-services-auth:19.0.0"
+    implementation "com.google.android.gms:play-services-auth:19.2.0"
     implementation "com.google.firebase:firebase-functions-ktx:20.0.0"
 
     // GeoFire (for Geoqueries solution)

--- a/firestore/build.gradle
+++ b/firestore/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.0.0'
         classpath 'com.google.gms:google-services:4.3.8'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21"
     }

--- a/functions/app/build.gradle
+++ b/functions/app/build.gradle
@@ -22,7 +22,7 @@ android {
 
 dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
 
     implementation "com.google.firebase:firebase-functions-ktx:20.0.0"
 }

--- a/functions/build.gradle
+++ b/functions/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.0.0'
         classpath 'com.google.gms:google-services:4.3.8'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21"
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/inappmessaging/app/build.gradle
+++ b/inappmessaging/app/build.gradle
@@ -24,7 +24,7 @@ android {
 dependencies {
     implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'androidx.browser:browser:1.0.0'
 
     implementation "com.google.firebase:firebase-inappmessaging-ktx:20.0.0"

--- a/inappmessaging/build.gradle
+++ b/inappmessaging/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.0.0'
         classpath 'com.google.gms:google-services:4.3.8'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21"
     }

--- a/installations/app/build.gradle
+++ b/installations/app/build.gradle
@@ -25,7 +25,7 @@ android {
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation 'androidx.core:core-ktx:1.6.0'
-    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 
     implementation 'com.google.firebase:firebase-installations:17.0.0'

--- a/installations/build.gradle
+++ b/installations/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.2.2"
+        classpath "com.android.tools.build:gradle:7.0.0"
         classpath 'com.google.gms:google-services:4.3.8'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21"
 

--- a/messaging/app/build.gradle
+++ b/messaging/app/build.gradle
@@ -22,14 +22,14 @@ android {
 
 dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation "com.google.firebase:firebase-messaging-ktx:22.0.0"
 
     // For an optimal experience using FCM, add the Firebase SDK
     // for Google Analytics. This is recommended, but not required.
     implementation 'com.google.firebase:firebase-analytics:19.0.0'
 
-    implementation "com.google.android.gms:play-services-auth:19.0.0"
+    implementation "com.google.android.gms:play-services-auth:19.2.0"
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/messaging/build.gradle
+++ b/messaging/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.0.0'
         classpath 'com.google.gms:google-services:4.3.8'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21"
     }

--- a/ml-functions/app/build.gradle
+++ b/ml-functions/app/build.gradle
@@ -31,7 +31,7 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
 
     // Import the Firebase BoM (see: https://firebase.google.com/docs/android/learn-more#bom)
     implementation platform('com.google.firebase:firebase-bom:26.1.1')

--- a/ml-functions/build.gradle
+++ b/ml-functions/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.0.0'
         classpath 'com.google.gms:google-services:4.3.8'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21"
     }

--- a/mlkit/app/build.gradle
+++ b/mlkit/app/build.gradle
@@ -30,7 +30,7 @@ android {
 
 dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'androidx.exifinterface:exifinterface:1.3.2'
     implementation "com.google.firebase:firebase-ml-common:22.1.2"
     implementation "com.google.firebase:firebase-ml-model-interpreter:22.0.4"

--- a/mlkit/build.gradle
+++ b/mlkit/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.0.0'
         classpath 'com.google.gms:google-services:4.3.8'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21"
     }

--- a/perf/app/build.gradle
+++ b/perf/app/build.gradle
@@ -22,7 +22,7 @@ android {
 
 dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation "com.google.firebase:firebase-config-ktx:21.0.0"
     implementation "com.google.firebase:firebase-perf-ktx:20.0.2"
 }

--- a/perf/build.gradle
+++ b/perf/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.0.0'
         classpath 'com.google.gms:google-services:4.3.8'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21"
     }

--- a/predictions/app/build.gradle
+++ b/predictions/app/build.gradle
@@ -24,7 +24,7 @@ android {
 dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.browser:browser:1.0.0'
-    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
 
     implementation "com.google.firebase:firebase-ads:20.2.0"
     implementation "com.google.firebase:firebase-analytics:19.0.0"

--- a/predictions/build.gradle
+++ b/predictions/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.0.0'
         classpath 'com.google.gms:google-services:4.3.8'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21"
     }

--- a/storage/app/build.gradle
+++ b/storage/app/build.gradle
@@ -22,7 +22,7 @@ android {
 
 dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation "com.google.firebase:firebase-storage-ktx:20.0.0"
 
     implementation 'com.firebaseui:firebase-ui-storage:7.2.0'

--- a/storage/build.gradle
+++ b/storage/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.0.0'
         classpath 'com.google.gms:google-services:4.3.8'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21"
     }

--- a/tasks/app/build.gradle
+++ b/tasks/app/build.gradle
@@ -22,7 +22,7 @@ android {
 
 dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
 
     implementation "com.google.firebase:firebase-auth-ktx:21.0.1"
 }

--- a/tasks/build.gradle
+++ b/tasks/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.0.0'
         classpath 'com.google.gms:google-services:4.3.8'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21"
     }

--- a/test-lab/app/build.gradle
+++ b/test-lab/app/build.gradle
@@ -28,7 +28,7 @@ repositories {
 
 dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation "com.google.firebase:firebase-iid:21.1.0"
 
     implementation(name:'cloudtestingscreenshotter_lib', ext:'aar')

--- a/test-lab/build.gradle
+++ b/test-lab/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.0.0'
         classpath 'com.google.gms:google-services:4.3.8'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21"
     }


### PR DESCRIPTION
This PR should add the changes from #311 and:
- update gradle/wrapper to use Gradle 7.0.2 (min required by AGP7)
- update the GitHub Actions workflow to use Java 11 (required by Gradle 7)