### PR TITLE
feature: Fixes #324 and B-193923794- Added Android Snippets for "Measure_ad_revenue" Page

### DIFF
--- a/analytics/app/src/main/java/com/google/firebase/example/analytics/MainActivity.java
+++ b/analytics/app/src/main/java/com/google/firebase/example/analytics/MainActivity.java
@@ -221,7 +221,7 @@ public class MainActivity extends AppCompatActivity {
         analytics.logEvent(FirebaseAnalytics.Event.SELECT_PROMOTION, promoParams);
         // [END apply_promo]
     }
-        // [START ad_Impression_moPub]
+        // [START ad_impression_moPub]
     @Override
     public void onImpression(@NonNull final String adUnitId, @Nullable final ImpressionData impressionData) {
 
@@ -240,9 +240,9 @@ public class MainActivity extends AppCompatActivity {
         }
 
     }
-        // [END ad_Impression_moPub]
+        // [END ad_impression_moPub]
 
-        // [START ad_Impression_applovin]
+        // [START ad_impression_applovin]
     @Override
     public void onAdRevenuePaid(final MaxAd impressionData) {
         double revenue = impressionData.getRevenue(); // In USD
@@ -260,10 +260,9 @@ public class MainActivity extends AppCompatActivity {
                 mFirebaseAnalytics.logEvent(FirebaseAnalytics.Event.AD_IMPRESSION, params);
         }
     }
-        // [END ad_Impression_applovin]
+        // [END ad_impression_applovin]
 
-        // [START ad_Impression_ironsource]
-        // Invoked when the ad was displayed successfully and the impression data was recorded
+        // [START ad_impression_ironsource]
     @Override
     public void onImpressionSuccess(ImpressionData impressionData) {
         // The onImpressionSuccess will be reported when the rewarded video and interstitial ad is opened.
@@ -279,5 +278,5 @@ public class MainActivity extends AppCompatActivity {
                 mFirebaseAnalytics.logEvent(FirebaseAnalytics.Event.AD_IMPRESSION, bundle);
         }
     }
-        // [END ad_Impression_ironsource]
+        // [END ad_impression_ironsource]
 }

--- a/analytics/app/src/main/java/com/google/firebase/example/analytics/MainActivity.java
+++ b/analytics/app/src/main/java/com/google/firebase/example/analytics/MainActivity.java
@@ -221,4 +221,63 @@ public class MainActivity extends AppCompatActivity {
         analytics.logEvent(FirebaseAnalytics.Event.SELECT_PROMOTION, promoParams);
         // [END apply_promo]
     }
+        // [START ad_Impression_moPub]
+    @Override
+    public void onImpression(@NonNull final String adUnitId, @Nullable final ImpressionData impressionData) {
+
+        if (impressionData != null) {
+                FirebaseAnalytics firebaseAnalytics = FirebaseAnalytics.getInstance(context);
+
+                Bundle params = new Bundle();
+                params.putString(FirebaseAnalytics.Param.AD_PLATFORM, "MoPub");
+                params.putString(FirebaseAnalytics.Param.AD_SOURCE, impressionData.network_name);
+                params.putString(FirebaseAnalytics.Param.AD_FORMAT, impressionData.adunit_format);
+                params.putString(FirebaseAnalytics.Param.AD_UNIT_NAME, impressionData.adunit_name);
+                params.putDouble(FirebaseAnalytics.Param.VALUE, impressionData.publisher_revenue);
+                params.putString(FirebaseAnalytics.Param.CURRENCY, impressionData.currency);
+                params.putString("precision", impressionData.precision);
+                mFirebaseAnalytics.logEvent(FirebaseAnalytics.Event.AD_IMPRESSION, params);
+        }
+
+    }
+        // [END ad_Impression_moPub]
+
+        // [START ad_Impression_applovin]
+    @Override
+    public void onAdRevenuePaid(final MaxAd impressionData) {
+        double revenue = impressionData.getRevenue(); // In USD
+
+        if (impressionData != null) {
+                FirebaseAnalytics firebaseAnalytics = FirebaseAnalytics.getInstance(context);
+
+                Bundle params = new Bundle();
+                params.putString(FirebaseAnalytics.Param.AD_PLATFORM, "AppLovin");
+                params.putString(FirebaseAnalytics.Param.AD_SOURCE, impressionData.getNetworkName());
+                params.putString(FirebaseAnalytics.Param.AD_FORMAT, impressionData.getFormat());
+                params.putString(FirebaseAnalytics.Param.AD_UNIT_NAME, impressionData.getAdUnitId());
+                params.putDouble(FirebaseAnalytics.Param.VALUE, revenue);
+                params.putString(FirebaseAnalytics.Param.CURRENCY, "USD"); // All Applovin revenue is sent in USD 
+                mFirebaseAnalytics.logEvent(FirebaseAnalytics.Event.AD_IMPRESSION, params);
+        }
+    }
+        // [END ad_Impression_applovin]
+
+        // [START ad_Impression_ironsource]
+        // Invoked when the ad was displayed successfully and the impression data was recorded
+    @Override
+    public void onImpressionSuccess(ImpressionData impressionData) {
+        // The onImpressionSuccess will be reported when the rewarded video and interstitial ad is opened.
+        // For banners, the impression is reported on load success. Log.d(TAG, "onImpressionSuccess" + impressionData);
+        if (impressionData != null) {
+                Bundle bundle = new Bundle();
+                bundle.putString(FirebaseAnalytics.Param.AD_PLATFORM, "ironSource");
+                bundle.putString(FirebaseAnalytics.Param.AD_SOURCE, impressionData.adNetwork());
+                bundle.putString(FirebaseAnalytics.Param.AD_FORMAT, impressionData.getAdUnit());
+                bundle.putString(FirebaseAnalytics.Param.AD_UNIT_NAME, impressionData.getAdUnit());
+                bundle.putString(FirebaseAnalytics.Param.CURRENCY, "USD");
+                bundle.putDouble(FirebaseAnalytics.Param.VALUE, impressionData.getRevenue());
+                mFirebaseAnalytics.logEvent(FirebaseAnalytics.Event.AD_IMPRESSION, bundle);
+        }
+    }
+        // [END ad_Impression_ironsource]
 }

--- a/analytics/app/src/main/java/com/google/firebase/example/analytics/kotlin/MainActivity.kt
+++ b/analytics/app/src/main/java/com/google/firebase/example/analytics/kotlin/MainActivity.kt
@@ -214,7 +214,7 @@ class MainActivity : AppCompatActivity() {
     // [START ad_Impression_applovin]
     override fun onAdRevenuePaid(impressionData: MaxAd) {
         if (impressionData != null) {
-           FirebaseAnalytics firebaseAnalytics = FirebaseAnalytics.getInstance(context);
+           val firebaseAnalytics = Firebase.analytics(context);
 
            firebaseAnalytics.logEvent(FirebaseAnalytics.Event.AD_IMPRESSION) {
                 param(FirebaseAnalytics.Param.AD_PLATFORM, "AppLovin")

--- a/analytics/app/src/main/java/com/google/firebase/example/analytics/kotlin/MainActivity.kt
+++ b/analytics/app/src/main/java/com/google/firebase/example/analytics/kotlin/MainActivity.kt
@@ -229,8 +229,7 @@ class MainActivity : AppCompatActivity() {
     // [END ad_Impression_applovin]
 
     // [START ad_Impression_ironsource]
-    @Override
-    public void onImpression(@NonNull final String adUnitId, @Nullable final ImpressionData impressionData) {
+    override fun onImpression(adUnitId: String, impressionData: ImpressionData?) {
 
         if (impressionData != null) {
             // Feed impression data into internal tools or send to third-party analytics

--- a/analytics/app/src/main/java/com/google/firebase/example/analytics/kotlin/MainActivity.kt
+++ b/analytics/app/src/main/java/com/google/firebase/example/analytics/kotlin/MainActivity.kt
@@ -233,7 +233,7 @@ class MainActivity : AppCompatActivity() {
 
         impressionData?.let {
             // Feed impression data into internal tools or send to third-party analytics
-            FirebaseAnalytics firebaseAnalytics = FirebaseAnalytics.getInstance(context);
+            val firebaseAnalytics = Firebase.analytics(context);
 
             firebaseAnalytics.logEvent(FirebaseAnalytics.Event.AD_IMPRESSION) {
             param(FirebaseAnalytics.Param.AD_PLATFORM, "MoPub")

--- a/analytics/app/src/main/java/com/google/firebase/example/analytics/kotlin/MainActivity.kt
+++ b/analytics/app/src/main/java/com/google/firebase/example/analytics/kotlin/MainActivity.kt
@@ -194,27 +194,28 @@ class MainActivity : AppCompatActivity() {
         // [END apply_promo]
     }
 
-    // [START ad_Impression_moPub]
-    override fun onImpressionSuccess(impressionData: ImpressionData?) {
-        // The onImpressionSuccess will be reported when the rewarded video and interstitial ad is opened.
-        // For banners, the impression is reported on load success. Log.d(TAG, "onImpressionSuccess" + impressionData);
+    // [START ad_impression_moPub]
+    override fun onImpression(adUnitId: String, impressionData: ImpressionData?) {
         impressionData?.let {
+            val firebaseAnalytics = FirebaseAnalytics.getInstance(context);
+
             firebaseAnalytics.logEvent(FirebaseAnalytics.Event.AD_IMPRESSION) {
-                param(FirebaseAnalytics.Param.AD_PLATFORM, "ironSource")
-                param(FirebaseAnalytics.Param.AD_SOURCE, impressionData.adNetwork())
-                param(FirebaseAnalytics.Param.AD_FORMAT, impressionData.getAdUnit())
-                param(FirebaseAnalytics.Param.AD_UNIT_NAME, impressionData.getAdUnit())
-                param(FirebaseAnalytics.Param.CURRENCY, "USD")
-                param(FirebaseAnalytics.Param.VALUE, impressionData.getRevenue())
+                param(FirebaseAnalytics.Param.AD_PLATFORM, "MoPub")
+                param(FirebaseAnalytics.Param.AD_SOURCE, impressionData.network_name)
+                param(FirebaseAnalytics.Param.AD_FORMAT, impressionData.adunit_format)
+                param(FirebaseAnalytics.Param.AD_UNIT_NAME, impressionData.adunit_name)
+                param(FirebaseAnalytics.Param.CURRENCY, impressionData.currency)
+                param(FirebaseAnalytics.Param.VALUE, impressionData.publisher_revenue)
+                param("precision", impressionData.precision)
             }
         }
     }
-    // [END ad_Impression_moPub]
+    // [END ad_impression_moPub]
 
-    // [START ad_Impression_applovin]
+    // [START ad_impression_applovin]
     override fun onAdRevenuePaid(impressionData: MaxAd) {
-        if (impressionData != null) {
-           val firebaseAnalytics = Firebase.analytics(context);
+        impressionData?.let {
+           val firebaseAnalytics = FirebaseAnalytics.getInstance(context);
 
            firebaseAnalytics.logEvent(FirebaseAnalytics.Event.AD_IMPRESSION) {
                 param(FirebaseAnalytics.Param.AD_PLATFORM, "AppLovin")
@@ -226,26 +227,23 @@ class MainActivity : AppCompatActivity() {
            }
         }   
     }
-    // [END ad_Impression_applovin]
+    // [END ad_impression_applovin]
 
-    // [START ad_Impression_ironsource]
-    override fun onImpression(adUnitId: String, impressionData: ImpressionData?) {
-
+    // [START ad_impression_ironsource]
+    override fun onImpressionSuccess(impressionData: ImpressionData?) {
+        // The onImpressionSuccess will be reported when the rewarded video and interstitial ad is opened.
+        // For banners, the impression is reported on load success. Log.d(TAG, "onImpressionSuccess" + impressionData);
+        val firebaseAnalytics = FirebaseAnalytics.getInstance(context);
         impressionData?.let {
-            // Feed impression data into internal tools or send to third-party analytics
-            val firebaseAnalytics = Firebase.analytics(context);
-
             firebaseAnalytics.logEvent(FirebaseAnalytics.Event.AD_IMPRESSION) {
-            param(FirebaseAnalytics.Param.AD_PLATFORM, "MoPub")
-            param(FirebaseAnalytics.Param.AD_SOURCE, impressionData.network_name)
-            param(FirebaseAnalytics.Param.AD_FORMAT, impressionData.adunit_format)
-            param(FirebaseAnalytics.Param.AD_UNIT_NAME, impressionData.adunit_name)
-            param(FirebaseAnalytics.Param.VALUE, impressionData.publisher_revenue)
-            param(FirebaseAnalytics.Param.CURRENCY, impressionData.currency)
-            param("precision", impressionData.precision)
+                param(FirebaseAnalytics.Param.AD_PLATFORM, "ironSource")
+                param(FirebaseAnalytics.Param.AD_SOURCE, impressionData.adNetwork())
+                param(FirebaseAnalytics.Param.AD_FORMAT, impressionData.getAdUnit())
+                param(FirebaseAnalytics.Param.AD_UNIT_NAME, impressionData.getAdUnit())
+                param(FirebaseAnalytics.Param.CURRENCY, "USD")
+                param(FirebaseAnalytics.Param.VALUE, impressionData.getRevenue())
             }
         }
-
     }
     // [END ad_Impression_ironsource]
 }

--- a/analytics/app/src/main/java/com/google/firebase/example/analytics/kotlin/MainActivity.kt
+++ b/analytics/app/src/main/java/com/google/firebase/example/analytics/kotlin/MainActivity.kt
@@ -198,7 +198,7 @@ class MainActivity : AppCompatActivity() {
     override fun onImpressionSuccess(impressionData: ImpressionData?) {
         // The onImpressionSuccess will be reported when the rewarded video and interstitial ad is opened.
         // For banners, the impression is reported on load success. Log.d(TAG, "onImpressionSuccess" + impressionData);
-        if (impressionData != null) {
+        impressionData?.let {
             firebaseAnalytics.logEvent(FirebaseAnalytics.Event.AD_IMPRESSION) {
                 param(FirebaseAnalytics.Param.AD_PLATFORM, "ironSource")
                 param(FirebaseAnalytics.Param.AD_SOURCE, impressionData.adNetwork())

--- a/analytics/app/src/main/java/com/google/firebase/example/analytics/kotlin/MainActivity.kt
+++ b/analytics/app/src/main/java/com/google/firebase/example/analytics/kotlin/MainActivity.kt
@@ -164,11 +164,42 @@ class MainActivity : AppCompatActivity() {
         analytics.logEvent(FirebaseAnalytics.Event.SELECT_PROMOTION, promoParams)
         // [END apply_promo]
     }
+    // Simulated ad_impression structures from mediation platforms to ensure that this project compiles
+    // Mopub simulated ad impression
+    val adUnitId = ""
+    class ImpressionData {
+        val network_name: String = ""
+        val adunit_format: String = ""
+        val adunit_name: String = ""
+        val currency: String = ""
+        val publisher_revenue: Double = 0.00
+        val precision = ""
+
+        //ironsource also uses ImpressionData so have added their methods below
+        fun adNetwork(): String {
+            return ""
+        }
+        fun getAdUnit(): String {
+            return ""
+        }
+        fun getRevenue(): Double {
+            return 0.00
+        }
+
+    }
+    // AppLovin simulated ad impression
+    class MaxAd {
+        val adUnitId: String = ""
+        val format: String = ""
+        val networkName: String = ""
+        val revenue: Double = 0.00
+    }
+
     // [START ad_impression_moPub]
     override fun onImpression(adUnitId: String, impressionData: ImpressionData?) {
         impressionData?.let {
-            val firebaseAnalytics = FirebaseAnalytics.getInstance(context)
-            firebaseAnalytics.logEvent(FirebaseAnalytics.Event.AD_IMPRESSION) {
+            val analytics = Firebase.analytics
+            analytics.logEvent(FirebaseAnalytics.Event.AD_IMPRESSION) {
                 param(FirebaseAnalytics.Param.AD_PLATFORM, "MoPub")
                 param(FirebaseAnalytics.Param.AD_SOURCE, impressionData.network_name)
                 param(FirebaseAnalytics.Param.AD_FORMAT, impressionData.adunit_format)
@@ -183,8 +214,8 @@ class MainActivity : AppCompatActivity() {
     // [START ad_impression_applovin]
     override fun onAdRevenuePaid(impressionData: MaxAd) {
         impressionData?.let {
-            val firebaseAnalytics = FirebaseAnalytics.getInstance(context)
-            firebaseAnalytics.logEvent(FirebaseAnalytics.Event.AD_IMPRESSION) {
+            val analytics = Firebase.analytics
+            analytics.logEvent(FirebaseAnalytics.Event.AD_IMPRESSION) {
                 param(FirebaseAnalytics.Param.AD_PLATFORM, "AppLovin")
                 param(FirebaseAnalytics.Param.AD_UNIT_NAME, impressionData.adUnitId)
                 param(FirebaseAnalytics.Param.AD_FORMAT, impressionData.format)
@@ -201,9 +232,9 @@ class MainActivity : AppCompatActivity() {
         // opened.
         // For banners, the impression is reported on load success. Log.d(TAG, "onImpressionSuccess" +
         // impressionData);
-        val firebaseAnalytics = FirebaseAnalytics.getInstance(context)
+        val analytics = Firebase.analytics
         impressionData?.let {
-            firebaseAnalytics.logEvent(FirebaseAnalytics.Event.AD_IMPRESSION) {
+            analytics.logEvent(FirebaseAnalytics.Event.AD_IMPRESSION) {
                 param(FirebaseAnalytics.Param.AD_PLATFORM, "ironSource")
                 param(FirebaseAnalytics.Param.AD_SOURCE, impressionData.adNetwork())
                 param(FirebaseAnalytics.Param.AD_FORMAT, impressionData.getAdUnit())

--- a/analytics/app/src/main/java/com/google/firebase/example/analytics/kotlin/MainActivity.kt
+++ b/analytics/app/src/main/java/com/google/firebase/example/analytics/kotlin/MainActivity.kt
@@ -193,4 +193,61 @@ class MainActivity : AppCompatActivity() {
         analytics.logEvent(FirebaseAnalytics.Event.SELECT_PROMOTION, promoParams)
         // [END apply_promo]
     }
+
+    // [START ad_Impression_moPub]
+    @Override
+    public void onImpressionSuccess(ImpressionData impressionData) {
+        // The onImpressionSuccess will be reported when the rewarded video and interstitial ad is opened.
+        // For banners, the impression is reported on load success. Log.d(TAG, "onImpressionSuccess" + impressionData);
+        if (impressionData != null) {
+            firebaseAnalytics.logEvent(FirebaseAnalytics.Event.AD_IMPRESSION) {
+                param(FirebaseAnalytics.Param.AD_PLATFORM, "ironSource")
+                param(FirebaseAnalytics.Param.AD_SOURCE, impressionData.adNetwork())
+                param(FirebaseAnalytics.Param.AD_FORMAT, impressionData.getAdUnit())
+                param(FirebaseAnalytics.Param.AD_UNIT_NAME, impressionData.getAdUnit())
+                param(FirebaseAnalytics.Param.CURRENCY, "USD")
+                param(FirebaseAnalytics.Param.VALUE, impressionData.getRevenue())
+            }
+        }
+    }
+    // [END ad_Impression_moPub]
+
+    // [START ad_Impression_applovin]
+    override fun onAdRevenuePaid(impressionData: MaxAd) {
+        if (impressionData != null) {
+           FirebaseAnalytics firebaseAnalytics = FirebaseAnalytics.getInstance(context);
+
+           firebaseAnalytics.logEvent(FirebaseAnalytics.Event.AD_IMPRESSION) {
+                param(FirebaseAnalytics.Param.AD_PLATFORM, "AppLovin")
+                param(FirebaseAnalytics.Param.AD_UNIT_NAME, impressionData.adUnitId)
+                param(FirebaseAnalytics.Param.AD_FORMAT, impressionData.format)
+                param(FirebaseAnalytics.Param.AD_SOURCE, impressionData.networkName)
+                param(FirebaseAnalytics.Param.VALUE, impressionData.revenue) 
+                param(FirebaseAnalytics.Param.CURRENCY, "USD") // All Applovin revenue is sent in USD 
+           }
+        }   
+    }
+    // [END ad_Impression_applovin]
+
+    // [START ad_Impression_ironsource]
+    @Override
+    public void onImpression(@NonNull final String adUnitId, @Nullable final ImpressionData impressionData) {
+
+        if (impressionData != null) {
+            // Feed impression data into internal tools or send to third-party analytics
+            FirebaseAnalytics firebaseAnalytics = FirebaseAnalytics.getInstance(context);
+
+            firebaseAnalytics.logEvent(FirebaseAnalytics.Event.AD_IMPRESSION) {
+            param(FirebaseAnalytics.Param.AD_PLATFORM, "MoPub")
+            param(FirebaseAnalytics.Param.AD_SOURCE, impressionData.network_name)
+            param(FirebaseAnalytics.Param.AD_FORMAT, impressionData.adunit_format)
+            param(FirebaseAnalytics.Param.AD_UNIT_NAME, impressionData.adunit_name)
+            param(FirebaseAnalytics.Param.VALUE, impressionData.publisher_revenue)
+            param(FirebaseAnalytics.Param.CURRENCY, impressionData.currency)
+            param("precision", impressionData.precision)
+            }
+        }
+
+    }
+    // [END ad_Impression_ironsource]
 }

--- a/analytics/app/src/main/java/com/google/firebase/example/analytics/kotlin/MainActivity.kt
+++ b/analytics/app/src/main/java/com/google/firebase/example/analytics/kotlin/MainActivity.kt
@@ -231,7 +231,7 @@ class MainActivity : AppCompatActivity() {
     // [START ad_Impression_ironsource]
     override fun onImpression(adUnitId: String, impressionData: ImpressionData?) {
 
-        if (impressionData != null) {
+        impressionData?.let {
             // Feed impression data into internal tools or send to third-party analytics
             FirebaseAnalytics firebaseAnalytics = FirebaseAnalytics.getInstance(context);
 

--- a/analytics/app/src/main/java/com/google/firebase/example/analytics/kotlin/MainActivity.kt
+++ b/analytics/app/src/main/java/com/google/firebase/example/analytics/kotlin/MainActivity.kt
@@ -1,5 +1,4 @@
 package com.google.firebase.example.analytics.kotlin
-
 import android.os.Bundle
 import android.os.Parcelable
 import androidx.appcompat.app.AppCompatActivity
@@ -8,66 +7,57 @@ import com.google.firebase.analytics.ktx.analytics
 import com.google.firebase.analytics.ktx.logEvent
 import com.google.firebase.example.analytics.R
 import com.google.firebase.ktx.Firebase
-
 class MainActivity : AppCompatActivity() {
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
         enhancedEcommerce()
     }
-
     fun enhancedEcommerce() {
         val analytics = Firebase.analytics
-
         // [START create_items]
-        val itemJeggings = Bundle().apply {
-            putString(FirebaseAnalytics.Param.ITEM_ID, "SKU_123")
-            putString(FirebaseAnalytics.Param.ITEM_NAME, "jeggings")
-            putString(FirebaseAnalytics.Param.ITEM_CATEGORY, "pants")
-            putString(FirebaseAnalytics.Param.ITEM_VARIANT, "black")
-            putString(FirebaseAnalytics.Param.ITEM_BRAND, "Google")
-            putDouble(FirebaseAnalytics.Param.PRICE, 9.99)
-        }
-
-        val itemBoots = Bundle().apply {
-            putString(FirebaseAnalytics.Param.ITEM_ID, "SKU_456")
-            putString(FirebaseAnalytics.Param.ITEM_NAME, "boots")
-            putString(FirebaseAnalytics.Param.ITEM_CATEGORY, "shoes")
-            putString(FirebaseAnalytics.Param.ITEM_VARIANT, "brown")
-            putString(FirebaseAnalytics.Param.ITEM_BRAND, "Google")
-            putDouble(FirebaseAnalytics.Param.PRICE, 24.99)
-        }
-
-        val itemSocks = Bundle().apply {
-            putString(FirebaseAnalytics.Param.ITEM_ID, "SKU_789")
-            putString(FirebaseAnalytics.Param.ITEM_NAME, "ankle_socks")
-            putString(FirebaseAnalytics.Param.ITEM_CATEGORY, "socks")
-            putString(FirebaseAnalytics.Param.ITEM_VARIANT, "red")
-            putString(FirebaseAnalytics.Param.ITEM_BRAND, "Google")
-            putDouble(FirebaseAnalytics.Param.PRICE, 5.99)
-        }
+        val itemJeggings =
+            Bundle().apply {
+                putString(FirebaseAnalytics.Param.ITEM_ID, "SKU_123")
+                putString(FirebaseAnalytics.Param.ITEM_NAME, "jeggings")
+                putString(FirebaseAnalytics.Param.ITEM_CATEGORY, "pants")
+                putString(FirebaseAnalytics.Param.ITEM_VARIANT, "black")
+                putString(FirebaseAnalytics.Param.ITEM_BRAND, "Google")
+                putDouble(FirebaseAnalytics.Param.PRICE, 9.99)
+            }
+        val itemBoots =
+            Bundle().apply {
+                putString(FirebaseAnalytics.Param.ITEM_ID, "SKU_456")
+                putString(FirebaseAnalytics.Param.ITEM_NAME, "boots")
+                putString(FirebaseAnalytics.Param.ITEM_CATEGORY, "shoes")
+                putString(FirebaseAnalytics.Param.ITEM_VARIANT, "brown")
+                putString(FirebaseAnalytics.Param.ITEM_BRAND, "Google")
+                putDouble(FirebaseAnalytics.Param.PRICE, 24.99)
+            }
+        val itemSocks =
+            Bundle().apply {
+                putString(FirebaseAnalytics.Param.ITEM_ID, "SKU_789")
+                putString(FirebaseAnalytics.Param.ITEM_NAME, "ankle_socks")
+                putString(FirebaseAnalytics.Param.ITEM_CATEGORY, "socks")
+                putString(FirebaseAnalytics.Param.ITEM_VARIANT, "red")
+                putString(FirebaseAnalytics.Param.ITEM_BRAND, "Google")
+                putDouble(FirebaseAnalytics.Param.PRICE, 5.99)
+            }
         // [END create_items]
-
         // [START view_item_list]
-        val itemJeggingsWithIndex = Bundle(itemJeggings).apply {
-            putLong(FirebaseAnalytics.Param.INDEX, 1)
-        }
-        val itemBootsWithIndex = Bundle(itemBoots).apply {
-            putLong(FirebaseAnalytics.Param.INDEX, 2)
-        }
-        val itemSocksWithIndex = Bundle(itemSocks).apply {
-            putLong(FirebaseAnalytics.Param.INDEX, 3)
-        }
-
+        val itemJeggingsWithIndex =
+            Bundle(itemJeggings).apply { putLong(FirebaseAnalytics.Param.INDEX, 1) }
+        val itemBootsWithIndex = Bundle(itemBoots).apply { putLong(FirebaseAnalytics.Param.INDEX, 2) }
+        val itemSocksWithIndex = Bundle(itemSocks).apply { putLong(FirebaseAnalytics.Param.INDEX, 3) }
         analytics.logEvent(FirebaseAnalytics.Event.VIEW_ITEM_LIST) {
             param(FirebaseAnalytics.Param.ITEM_LIST_ID, "L001")
             param(FirebaseAnalytics.Param.ITEM_LIST_NAME, "Related products")
-            param(FirebaseAnalytics.Param.ITEMS,
-                    arrayOf(itemJeggingsWithIndex, itemBootsWithIndex, itemSocksWithIndex))
+            param(
+                FirebaseAnalytics.Param.ITEMS,
+                arrayOf(itemJeggingsWithIndex, itemBootsWithIndex, itemSocksWithIndex)
+            )
         }
         // [END view_item_list]
-
         // [START select_item]
         analytics.logEvent(FirebaseAnalytics.Event.SELECT_ITEM) {
             param(FirebaseAnalytics.Param.ITEM_LIST_ID, "L001")
@@ -75,7 +65,6 @@ class MainActivity : AppCompatActivity() {
             param(FirebaseAnalytics.Param.ITEMS, arrayOf(itemJeggings))
         }
         // [END select_item]
-
         // [START view_product_details]
         analytics.logEvent(FirebaseAnalytics.Event.VIEW_ITEM) {
             param(FirebaseAnalytics.Param.CURRENCY, "USD")
@@ -83,34 +72,25 @@ class MainActivity : AppCompatActivity() {
             param(FirebaseAnalytics.Param.ITEMS, arrayOf(itemJeggings))
         }
         // [END view_product_details]
-
         // [START add_to_cart_wishlist]
-        val itemJeggingsWishlist = Bundle(itemJeggings).apply {
-            putLong(FirebaseAnalytics.Param.QUANTITY, 2)
-        }
-
+        val itemJeggingsWishlist =
+            Bundle(itemJeggings).apply { putLong(FirebaseAnalytics.Param.QUANTITY, 2) }
         analytics.logEvent(FirebaseAnalytics.Event.ADD_TO_WISHLIST) {
             param(FirebaseAnalytics.Param.CURRENCY, "USD")
             param(FirebaseAnalytics.Param.VALUE, 2 * 9.99)
             param(FirebaseAnalytics.Param.ITEMS, arrayOf(itemJeggingsWishlist))
         }
         // [END add_to_cart_wishlist]
-
         // [START view_cart]
-        val itemJeggingsCart = Bundle(itemJeggings).apply {
-            putLong(FirebaseAnalytics.Param.QUANTITY, 2)
-        }
-        val itemBootsCart = Bundle(itemBoots).apply {
-            putLong(FirebaseAnalytics.Param.QUANTITY, 1)
-        }
-
+        val itemJeggingsCart =
+            Bundle(itemJeggings).apply { putLong(FirebaseAnalytics.Param.QUANTITY, 2) }
+        val itemBootsCart = Bundle(itemBoots).apply { putLong(FirebaseAnalytics.Param.QUANTITY, 1) }
         analytics.logEvent(FirebaseAnalytics.Event.VIEW_CART) {
             param(FirebaseAnalytics.Param.CURRENCY, "USD")
             param(FirebaseAnalytics.Param.VALUE, 2 * 9.99 + 1 * 24.99)
             param(FirebaseAnalytics.Param.ITEMS, arrayOf(itemJeggingsCart, itemBootsCart))
         }
         // [END view_cart]
-
         // [START remove_from_cart]
         analytics.logEvent(FirebaseAnalytics.Event.REMOVE_FROM_CART) {
             param(FirebaseAnalytics.Param.CURRENCY, "USD")
@@ -118,7 +98,6 @@ class MainActivity : AppCompatActivity() {
             param(FirebaseAnalytics.Param.ITEMS, arrayOf(itemBootsCart))
         }
         // [END remove_from_cart]
-
         // [START start_checkout]
         analytics.logEvent(FirebaseAnalytics.Event.BEGIN_CHECKOUT) {
             param(FirebaseAnalytics.Param.CURRENCY, "USD")
@@ -127,7 +106,6 @@ class MainActivity : AppCompatActivity() {
             param(FirebaseAnalytics.Param.ITEMS, arrayOf(itemJeggingsCart))
         }
         // [END start_checkout]
-
         // [START add_shipping]
         analytics.logEvent(FirebaseAnalytics.Event.ADD_SHIPPING_INFO) {
             param(FirebaseAnalytics.Param.CURRENCY, "USD")
@@ -137,7 +115,6 @@ class MainActivity : AppCompatActivity() {
             param(FirebaseAnalytics.Param.ITEMS, arrayOf(itemJeggingsCart))
         }
         // [END add_shipping]
-
         // [START add_payment]
         analytics.logEvent(FirebaseAnalytics.Event.ADD_PAYMENT_INFO) {
             param(FirebaseAnalytics.Param.CURRENCY, "USD")
@@ -147,7 +124,6 @@ class MainActivity : AppCompatActivity() {
             param(FirebaseAnalytics.Param.ITEMS, arrayOf(itemJeggingsCart))
         }
         // [END add_payment]
-
         // [START log_purchase]
         analytics.logEvent(FirebaseAnalytics.Event.PURCHASE) {
             param(FirebaseAnalytics.Param.TRANSACTION_ID, "T12345")
@@ -160,45 +136,38 @@ class MainActivity : AppCompatActivity() {
             param(FirebaseAnalytics.Param.ITEMS, arrayOf(itemJeggingsCart))
         }
         // [END log_purchase]
-
         // [START log_refund]
         analytics.logEvent(FirebaseAnalytics.Event.REFUND) {
             param(FirebaseAnalytics.Param.TRANSACTION_ID, "T12345")
             param(FirebaseAnalytics.Param.AFFILIATION, "Google Store")
             param(FirebaseAnalytics.Param.CURRENCY, "USD")
             param(FirebaseAnalytics.Param.VALUE, 9.99)
-
             // (Optional) for partial refunds, define the item ID and quantity of refunded items
             param(FirebaseAnalytics.Param.ITEM_ID, "SKU_123")
             param(FirebaseAnalytics.Param.QUANTITY, 1)
-
             param(FirebaseAnalytics.Param.ITEMS, arrayOf(itemJeggings))
         }
         // [END log_refund]
-
         // [START apply_promo]
-        val promoParams = Bundle().apply {
-            putString(FirebaseAnalytics.Param.PROMOTION_ID, "SUMMER_FUN")
-            putString(FirebaseAnalytics.Param.PROMOTION_NAME, "Summer Sale")
-            putString(FirebaseAnalytics.Param.CREATIVE_NAME, "summer2020_promo.jpg")
-            putString(FirebaseAnalytics.Param.CREATIVE_SLOT, "featured_app_1")
-            putString(FirebaseAnalytics.Param.LOCATION_ID, "HERO_BANNER")
-            putParcelableArray(FirebaseAnalytics.Param.ITEMS, arrayOf<Parcelable>(itemJeggings))
-        }
-
+        val promoParams =
+            Bundle().apply {
+                putString(FirebaseAnalytics.Param.PROMOTION_ID, "SUMMER_FUN")
+                putString(FirebaseAnalytics.Param.PROMOTION_NAME, "Summer Sale")
+                putString(FirebaseAnalytics.Param.CREATIVE_NAME, "summer2020_promo.jpg")
+                putString(FirebaseAnalytics.Param.CREATIVE_SLOT, "featured_app_1")
+                putString(FirebaseAnalytics.Param.LOCATION_ID, "HERO_BANNER")
+                putParcelableArray(FirebaseAnalytics.Param.ITEMS, arrayOf<Parcelable>(itemJeggings))
+            }
         // Promotion displayed
         analytics.logEvent(FirebaseAnalytics.Event.VIEW_PROMOTION, promoParams)
-
         // Promotion selected
         analytics.logEvent(FirebaseAnalytics.Event.SELECT_PROMOTION, promoParams)
         // [END apply_promo]
     }
-
     // [START ad_impression_moPub]
     override fun onImpression(adUnitId: String, impressionData: ImpressionData?) {
         impressionData?.let {
-            val firebaseAnalytics = FirebaseAnalytics.getInstance(context);
-
+            val firebaseAnalytics = FirebaseAnalytics.getInstance(context)
             firebaseAnalytics.logEvent(FirebaseAnalytics.Event.AD_IMPRESSION) {
                 param(FirebaseAnalytics.Param.AD_PLATFORM, "MoPub")
                 param(FirebaseAnalytics.Param.AD_SOURCE, impressionData.network_name)
@@ -211,29 +180,28 @@ class MainActivity : AppCompatActivity() {
         }
     }
     // [END ad_impression_moPub]
-
     // [START ad_impression_applovin]
     override fun onAdRevenuePaid(impressionData: MaxAd) {
         impressionData?.let {
-           val firebaseAnalytics = FirebaseAnalytics.getInstance(context);
-
-           firebaseAnalytics.logEvent(FirebaseAnalytics.Event.AD_IMPRESSION) {
+            val firebaseAnalytics = FirebaseAnalytics.getInstance(context)
+            firebaseAnalytics.logEvent(FirebaseAnalytics.Event.AD_IMPRESSION) {
                 param(FirebaseAnalytics.Param.AD_PLATFORM, "AppLovin")
                 param(FirebaseAnalytics.Param.AD_UNIT_NAME, impressionData.adUnitId)
                 param(FirebaseAnalytics.Param.AD_FORMAT, impressionData.format)
                 param(FirebaseAnalytics.Param.AD_SOURCE, impressionData.networkName)
-                param(FirebaseAnalytics.Param.VALUE, impressionData.revenue) 
-                param(FirebaseAnalytics.Param.CURRENCY, "USD") // All Applovin revenue is sent in USD 
-           }
-        }   
+                param(FirebaseAnalytics.Param.VALUE, impressionData.revenue)
+                param(FirebaseAnalytics.Param.CURRENCY, "USD") // All Applovin revenue is sent in USD
+            }
+        }
     }
     // [END ad_impression_applovin]
-
     // [START ad_impression_ironsource]
     override fun onImpressionSuccess(impressionData: ImpressionData?) {
-        // The onImpressionSuccess will be reported when the rewarded video and interstitial ad is opened.
-        // For banners, the impression is reported on load success. Log.d(TAG, "onImpressionSuccess" + impressionData);
-        val firebaseAnalytics = FirebaseAnalytics.getInstance(context);
+        // The onImpressionSuccess will be reported when the rewarded video and interstitial ad is
+        // opened.
+        // For banners, the impression is reported on load success. Log.d(TAG, "onImpressionSuccess" +
+        // impressionData);
+        val firebaseAnalytics = FirebaseAnalytics.getInstance(context)
         impressionData?.let {
             firebaseAnalytics.logEvent(FirebaseAnalytics.Event.AD_IMPRESSION) {
                 param(FirebaseAnalytics.Param.AD_PLATFORM, "ironSource")

--- a/analytics/app/src/main/java/com/google/firebase/example/analytics/kotlin/MainActivity.kt
+++ b/analytics/app/src/main/java/com/google/firebase/example/analytics/kotlin/MainActivity.kt
@@ -195,8 +195,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     // [START ad_Impression_moPub]
-    @Override
-    public void onImpressionSuccess(ImpressionData impressionData) {
+    override fun onImpressionSuccess(impressionData: ImpressionData?) {
         // The onImpressionSuccess will be reported when the rewarded video and interstitial ad is opened.
         // For banners, the impression is reported on load success. Log.d(TAG, "onImpressionSuccess" + impressionData);
         if (impressionData != null) {

--- a/analytics/app/src/main/java/com/google/firebase/example/analytics/kotlin/MainActivity.kt
+++ b/analytics/app/src/main/java/com/google/firebase/example/analytics/kotlin/MainActivity.kt
@@ -245,5 +245,5 @@ class MainActivity : AppCompatActivity() {
             }
         }
     }
-    // [END ad_Impression_ironsource]
+    // [END ad_impression_ironsource]
 }


### PR DESCRIPTION
Fixes #324 
Including snippets for AppLovin, Mopub and Ironsource. AppLovin code is the only new code added over the existing code shown in the Measure Ad Revenue Page in Helpcenter. https://firebase.google.com/docs/analytics/measure-ad-revenue.