### PR TITLE
Add impression snippets for java and kotlin 324

### DIFF
--- a/analytics/app/build.gradle
+++ b/analytics/app/build.gradle
@@ -19,13 +19,22 @@ android {
         }
     }
 }
+repositories {
+    maven {
+        // Ironsource library used for ad_impression snippets
+        url "https://android-sdk.is.com/"
+    }
+}
 
 dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.3.1'
-
     implementation "com.google.firebase:firebase-analytics:19.0.0"
     implementation "com.google.firebase:firebase-analytics-ktx:19.0.0"
+    // Ironsource and AppLovin libraries used for ad_impression snippets
+    implementation 'com.applovin:applovin-sdk:+'
+    implementation 'com.ironsource.sdk:mediationsdk:7.2.1.1'
+
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/analytics/app/src/main/java/com/google/firebase/example/analytics/MainActivity.java
+++ b/analytics/app/src/main/java/com/google/firebase/example/analytics/MainActivity.java
@@ -21,8 +21,7 @@ import android.os.Parcelable;
 import androidx.appcompat.app.AppCompatActivity;
 import com.google.firebase.analytics.FirebaseAnalytics;
 
-//  Disregard the below 5 lines which replicate ad_impression data being sent from 3rd parties and are not required for Firebase implementations.
-// Added 3rd party imports to support ad_impression snippets
+// importing libraries to support 3rd party ad_impression snippets
 import com.applovin.mediation.MaxAd;
 import com.applovin.mediation.MaxAdRevenueListener;
 import com.ironsource.mediationsdk.impressionData.ImpressionData;
@@ -30,7 +29,7 @@ import com.ironsource.mediationsdk.impressionData.ImpressionDataListener;
 
 
 public class MainActivity extends AppCompatActivity
-        //  Disregard the line below as its used to replicate ad_impression data being sent from 3rd parties and is not required for Firebase implementations.
+// importing libraries to support 3rd party ad_impression snippets
         implements MaxAdRevenueListener, ImpressionDataListener {
 
     @Override

--- a/analytics/app/src/main/java/com/google/firebase/example/analytics/kotlin/MainActivity.kt
+++ b/analytics/app/src/main/java/com/google/firebase/example/analytics/kotlin/MainActivity.kt
@@ -8,15 +8,16 @@ import com.google.firebase.analytics.ktx.analytics
 import com.google.firebase.analytics.ktx.logEvent
 import com.google.firebase.example.analytics.R
 import com.google.firebase.ktx.Firebase
-//  Disregard the below 5 lines which replicate ad_impression data being sent from 3rd parties and are not required for Firebase implementations.
-// Added 3rd party imports to support ad_impression snippets
+// importing libraries to support 3rd party ad_impression snippets
 import com.ironsource.mediationsdk.impressionData.ImpressionDataListener
 import com.ironsource.mediationsdk.impressionData.ImpressionData
 import com.applovin.mediation.MaxAd
 import com.applovin.mediation.MaxAdRevenueListener
 
 
-class MainActivity : AppCompatActivity(), MaxAdRevenueListener, ImpressionDataListener {
+class MainActivity : AppCompatActivity(),
+    // importing libraries to support 3rd party ad_impression snippets
+    MaxAdRevenueListener, ImpressionDataListener {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)

--- a/analytics/settings.gradle
+++ b/analytics/settings.gradle
@@ -1,1 +1,10 @@
 include ':app'
+
+// Ironsource library used for ad_impression snippets
+dependencyResolutionManagement {
+    repositories {
+        maven {
+            url 'https://android-sdk.is.com/'
+        }
+    }
+}


### PR DESCRIPTION
feature: added 3rd party sample`ad_impression` snippets for both Kotlin and Java to address issue #324 
added 3rd Party libraries so that the project will build and show the snippets in the correct format including "override" modifier.