### PR TITLE
check API Level in runtime before requesting notifications permission

### DIFF
--- a/messaging/app/src/main/java/com/google/firebase/example/messaging/MainActivity.java
+++ b/messaging/app/src/main/java/com/google/firebase/example/messaging/MainActivity.java
@@ -123,21 +123,21 @@ public class MainActivity extends AppCompatActivity {
                 }
             });
 
-    // [START_EXCLUDE]
-    @RequiresApi(33)
-    // [END_EXCLUDE]
     private void askNotificationPermission() {
-        if (ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) ==
-                PackageManager.PERMISSION_GRANTED) {
-            // FCM SDK (and your app) can post notifications.
-        } else if (shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS)) {
-            // TODO: display an educational UI explaining to the user the features that will be enabled
-            //       by them granting the POST_NOTIFICATION permission. This UI should provide the user
-            //       "OK" and "No thanks" buttons. If the user selects "OK," directly request the permission.
-            //       If the user selects "No thanks," allow the user to continue without notifications.
-        } else {
-            // Directly ask for the permission
-            requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS);
+        // This is only necessary for API level >= 33 (TIRAMISU)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            if (ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) ==
+                    PackageManager.PERMISSION_GRANTED) {
+                // FCM SDK (and your app) can post notifications.
+            } else if (shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS)) {
+                // TODO: display an educational UI explaining to the user the features that will be enabled
+                //       by them granting the POST_NOTIFICATION permission. This UI should provide the user
+                //       "OK" and "No thanks" buttons. If the user selects "OK," directly request the permission.
+                //       If the user selects "No thanks," allow the user to continue without notifications.
+            } else {
+                // Directly ask for the permission
+                requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS);
+            }
         }
     }
     // [END ask_post_notifications]

--- a/messaging/app/src/main/java/com/google/firebase/example/messaging/kotlin/MainActivity.kt
+++ b/messaging/app/src/main/java/com/google/firebase/example/messaging/kotlin/MainActivity.kt
@@ -2,6 +2,7 @@ package com.google.firebase.example.messaging.kotlin
 
 import android.Manifest
 import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.widget.Toast
@@ -109,22 +110,22 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    // [START_EXCLUDE]
-    @RequiresApi(33)
-    // [END_EXCLUDE]
     private fun askNotificationPermission() {
-        if (ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) ==
-            PackageManager.PERMISSION_GRANTED
-        ) {
-            // FCM SDK (and your app) can post notifications.
-        } else if (shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS)) {
-            // TODO: display an educational UI explaining to the user the features that will be enabled
-            //       by them granting the POST_NOTIFICATION permission. This UI should provide the user
-            //       "OK" and "No thanks" buttons. If the user selects "OK," directly request the permission.
-            //       If the user selects "No thanks," allow the user to continue without notifications.
-        } else {
-            // Directly ask for the permission
-            requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+        // This is only necessary for API level >= 33 (TIRAMISU)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            if (ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) ==
+                PackageManager.PERMISSION_GRANTED
+            ) {
+                // FCM SDK (and your app) can post notifications.
+            } else if (shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS)) {
+                // TODO: display an educational UI explaining to the user the features that will be enabled
+                //       by them granting the POST_NOTIFICATION permission. This UI should provide the user
+                //       "OK" and "No thanks" buttons. If the user selects "OK," directly request the permission.
+                //       If the user selects "No thanks," allow the user to continue without notifications.
+            } else {
+                // Directly ask for the permission
+                requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+            }
         }
     }
     // [END ask_post_notifications]


### PR DESCRIPTION
Instead of omitting the `@RequiresApi(33)` annotation in our docs, it might be better for developers if we show them how to check the API level during runtime before requesting the `POST_NOTIFICATIONS` permission.