### PR TITLE
add applovin and ironsource to dpebot's blocklist

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,9 @@ allprojects {
     def isBlocked = { candidate ->
         def blocklist = [
             'androidx.browser:browser',
-            'com.facebook.android:facebook-android-sdk'
+            'com.facebook.android:facebook-android-sdk',
+            'com.applovin:applovin-sdk',
+            'com.ironsource.sdk:mediationsdk'
         ]
         return blocklist.any { word ->
             return candidate.toString().contains(word)


### PR DESCRIPTION
Sometimes dpebot opens PRs to update these 3rd party dependencies, which doesn't really add value to our repo (see #385 for example). This PR should add both dependencies to our blocklist so that dpebot stops updating them.
We can update them manually if we ever need to change their corresponding snippets.