### PR TITLE
chore(firestore): remove explicit grpc-oktthp dependency

### DIFF
--- a/firestore/app/build.gradle
+++ b/firestore/app/build.gradle
@@ -48,9 +48,6 @@ dependencies {
 
     // GeoFire (for Geoqueries solution)
     implementation "com.firebase:geofire-android-common:3.2.0"
-
-    // OkHttp (for Android 11+)
-    implementation "io.grpc:grpc-okhttp:1.49.1"
 }
 
 apply plugin: 'com.google.gms.google-services'


### PR DESCRIPTION
This dependency was originally added to work around an error with an outdated version of okhttp (see https://stackoverflow.com/a/68231205/5861618).
Firestore has now updated their okhttp version, so we no longer need to explicitly set this.