### PR TITLE
refactor(*): move namespace from AndroidManifest.xml to build.gradle file

### DIFF
--- a/admob/app/build.gradle
+++ b/admob/app/build.gradle
@@ -19,6 +19,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    namespace 'devrel.firebase.google.com.firebaseoptions'
 }
 
 dependencies {

--- a/admob/app/src/main/AndroidManifest.xml
+++ b/admob/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="devrel.firebase.google.com.firebaseoptions">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/analytics/app/build.gradle
+++ b/analytics/app/build.gradle
@@ -19,6 +19,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    namespace 'com.google.firebase.example.analytics'
 }
 repositories {
     maven {

--- a/analytics/app/src/main/AndroidManifest.xml
+++ b/analytics/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.google.firebase.example.analytics">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
             android:allowBackup="true"

--- a/appcheck/app/build.gradle
+++ b/appcheck/app/build.gradle
@@ -25,6 +25,7 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    namespace 'com.google.firebase.example.appcheck'
 }
 
 dependencies {

--- a/appcheck/app/src/main/AndroidManifest.xml
+++ b/appcheck/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.firebase.example.appcheck">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/auth/app/build.gradle
+++ b/auth/app/build.gradle
@@ -18,6 +18,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    namespace 'com.google.firebase.quickstart.auth'
 }
 
 dependencies {

--- a/auth/app/src/main/AndroidManifest.xml
+++ b/auth/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.firebase.quickstart.auth">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/config/app/build.gradle
+++ b/config/app/build.gradle
@@ -29,6 +29,7 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+    namespace 'com.google.firebase.quickstart.config'
 }
 
 dependencies {

--- a/config/app/src/main/AndroidManifest.xml
+++ b/config/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.firebase.quickstart.config">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/crashlytics/app/build.gradle
+++ b/crashlytics/app/build.gradle
@@ -20,6 +20,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    namespace 'com.google.firebase.example.crashlytics'
 }
 
 dependencies {

--- a/crashlytics/app/src/main/AndroidManifest.xml
+++ b/crashlytics/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.firebase.example.crashlytics">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/database/app/build.gradle
+++ b/database/app/build.gradle
@@ -23,6 +23,7 @@ android {
         exclude 'META-INF/LICENSE-FIREBASE.txt'
         exclude 'META-INF/NOTICE'
     }
+    namespace 'com.google.firebase.referencecode.database'
 }
 
 dependencies {

--- a/database/app/src/main/AndroidManifest.xml
+++ b/database/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.firebase.referencecode.database">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/dl-invites/app/build.gradle
+++ b/dl-invites/app/build.gradle
@@ -18,6 +18,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    namespace 'com.google.firebase.dynamicinvites'
 }
 
 dependencies {

--- a/dl-invites/app/src/main/AndroidManifest.xml
+++ b/dl-invites/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.google.firebase.dynamicinvites">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <application
         android:allowBackup="true"

--- a/dynamic-links/app/build.gradle
+++ b/dynamic-links/app/build.gradle
@@ -18,6 +18,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    namespace 'com.google.firebase.quickstart.dynamiclinks'
 }
 
 dependencies {

--- a/dynamic-links/app/src/main/AndroidManifest.xml
+++ b/dynamic-links/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.firebase.quickstart.dynamiclinks">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/firebaseoptions/app/build.gradle
+++ b/firebaseoptions/app/build.gradle
@@ -18,6 +18,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    namespace 'devrel.firebase.google.com.firebaseoptions'
 }
 
 dependencies {

--- a/firebaseoptions/app/src/main/AndroidManifest.xml
+++ b/firebaseoptions/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="devrel.firebase.google.com.firebaseoptions">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
             android:allowBackup="true"

--- a/firestore/app/build.gradle
+++ b/firestore/app/build.gradle
@@ -24,6 +24,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    namespace 'com.google.example.firestore'
 }
 
 repositories {

--- a/firestore/app/src/main/AndroidManifest.xml
+++ b/firestore/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.example.firestore">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/functions/app/build.gradle
+++ b/functions/app/build.gradle
@@ -18,6 +18,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    namespace 'devrel.firebase.google.com.functions'
 }
 
 dependencies {

--- a/functions/app/src/main/AndroidManifest.xml
+++ b/functions/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="devrel.firebase.google.com.functions">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
             android:allowBackup="true"

--- a/inappmessaging/app/build.gradle
+++ b/inappmessaging/app/build.gradle
@@ -19,6 +19,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    namespace 'devrel.firebase.google.com.firebaseoptions'
 }
 
 dependencies {

--- a/inappmessaging/app/src/main/AndroidManifest.xml
+++ b/inappmessaging/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="devrel.firebase.google.com.firebaseoptions">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <application
         android:allowBackup="true"

--- a/installations/app/build.gradle
+++ b/installations/app/build.gradle
@@ -21,6 +21,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+    namespace 'com.google.samples.snippet'
 }
 
 dependencies {

--- a/installations/app/src/main/AndroidManifest.xml
+++ b/installations/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.samples.snippet">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/messaging/app/build.gradle
+++ b/messaging/app/build.gradle
@@ -18,6 +18,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    namespace 'com.google.firebase.example.messaging'
 }
 
 dependencies {

--- a/messaging/app/src/main/AndroidManifest.xml
+++ b/messaging/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.firebase.example.messaging">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/mlkit/app/build.gradle
+++ b/mlkit/app/build.gradle
@@ -26,6 +26,7 @@ android {
         exclude 'META-INF/androidx.exifinterface_exifinterface.version'
         exclude 'META-INF/proguard/androidx-annotations.pro'
     }
+    namespace 'devrel.firebase.google.com.firebaseoptions'
 }
 
 dependencies {

--- a/mlkit/app/src/main/AndroidManifest.xml
+++ b/mlkit/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="devrel.firebase.google.com.firebaseoptions">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/perf/app/build.gradle
+++ b/perf/app/build.gradle
@@ -20,6 +20,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    namespace 'devrel.firebase.google.com.firebaseoptions'
 }
 
 dependencies {

--- a/perf/app/src/main/AndroidManifest.xml
+++ b/perf/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="devrel.firebase.google.com.firebaseoptions">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/storage/app/build.gradle
+++ b/storage/app/build.gradle
@@ -18,6 +18,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    namespace 'com.google.firebase.referencecode.storage'
 }
 
 dependencies {

--- a/storage/app/src/main/AndroidManifest.xml
+++ b/storage/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.firebase.referencecode.storage">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/tasks/app/build.gradle
+++ b/tasks/app/build.gradle
@@ -19,6 +19,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    namespace 'com.google.firebase.quickstart.tasks'
 }
 
 dependencies {

--- a/tasks/app/src/main/AndroidManifest.xml
+++ b/tasks/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.firebase.quickstart.tasks">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/test-lab/app/build.gradle
+++ b/test-lab/app/build.gradle
@@ -18,6 +18,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    namespace 'devrel.firebase.google.com.firebaseoptions'
 }
 
 repositories {

--- a/test-lab/app/src/main/AndroidManifest.xml
+++ b/test-lab/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="devrel.firebase.google.com.firebaseoptions">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
Starting in AGP 7.3.0, setting the ~package~ namespace on the AndroidManifest.xml file has been [deprecated](https://developer.android.com/studio/build/configure-app-module#set-namespace) in favor of setting it on the build.gradle file.

This PR should update our snippets' apps to move the namespace to build.gradle.