### PR TITLE
refactor(auth, database, firestore): add nullability annotations to java snippets

### DIFF
--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/MainActivity.java
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/MainActivity.java
@@ -516,8 +516,8 @@ public class MainActivity extends AppCompatActivity {
                 .setActivity(this)
                 .setCallbacks(new PhoneAuthProvider.OnVerificationStateChangedCallbacks() {
                     @Override
-                    public void onCodeSent(String verificationId,
-                                           PhoneAuthProvider.ForceResendingToken forceResendingToken) {
+                    public void onCodeSent(@NonNull String verificationId,
+                                           @NonNull PhoneAuthProvider.ForceResendingToken forceResendingToken) {
                         // Save the verification id somewhere
                         // ...
 
@@ -526,13 +526,13 @@ public class MainActivity extends AppCompatActivity {
                     }
 
                     @Override
-                    public void onVerificationCompleted(PhoneAuthCredential phoneAuthCredential) {
+                    public void onVerificationCompleted(@NonNull PhoneAuthCredential phoneAuthCredential) {
                         // Sign in with the credential
                         // ...
                     }
 
                     @Override
-                    public void onVerificationFailed(FirebaseException e) {
+                    public void onVerificationFailed(@NonNull FirebaseException e) {
                         // ...
                     }
                 })
@@ -563,14 +563,14 @@ public class MainActivity extends AppCompatActivity {
                 .setActivity(this)
                 .setCallbacks(new PhoneAuthProvider.OnVerificationStateChangedCallbacks() {
                     @Override
-                    public void onVerificationCompleted(PhoneAuthCredential credential) {
+                    public void onVerificationCompleted(@NonNull PhoneAuthCredential credential) {
                         // Instant verification is applied and a credential is directly returned.
                         // ...
                     }
 
                     // [START_EXCLUDE]
                     @Override
-                    public void onVerificationFailed(FirebaseException e) {
+                    public void onVerificationFailed(@NonNull FirebaseException e) {
 
                     }
                     // [END_EXCLUDE]

--- a/auth/app/src/main/java/com/google/firebase/quickstart/auth/PhoneAuthActivity.java
+++ b/auth/app/src/main/java/com/google/firebase/quickstart/auth/PhoneAuthActivity.java
@@ -45,7 +45,7 @@ public class PhoneAuthActivity extends Activity {
         mCallbacks = new PhoneAuthProvider.OnVerificationStateChangedCallbacks() {
 
             @Override
-            public void onVerificationCompleted(PhoneAuthCredential credential) {
+            public void onVerificationCompleted(@NonNull PhoneAuthCredential credential) {
                 // This callback will be invoked in two situations:
                 // 1 - Instant verification. In some cases the phone number can be instantly
                 //     verified without needing to send or enter a verification code.
@@ -58,7 +58,7 @@ public class PhoneAuthActivity extends Activity {
             }
 
             @Override
-            public void onVerificationFailed(FirebaseException e) {
+            public void onVerificationFailed(@NonNull FirebaseException e) {
                 // This callback is invoked in an invalid request for verification is made,
                 // for instance if the the phone number format is not valid.
                 Log.w(TAG, "onVerificationFailed", e);

--- a/database/app/src/main/java/com/google/firebase/referencecode/database/MainActivity.java
+++ b/database/app/src/main/java/com/google/firebase/referencecode/database/MainActivity.java
@@ -16,6 +16,8 @@
 package com.google.firebase.referencecode.database;
 
 import android.os.Bundle;
+
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import android.util.Log;
 
@@ -48,7 +50,7 @@ public class MainActivity extends AppCompatActivity {
         // Read from the database
         myRef.addValueEventListener(new ValueEventListener() {
             @Override
-            public void onDataChange(DataSnapshot dataSnapshot) {
+            public void onDataChange(@NonNull DataSnapshot dataSnapshot) {
                 // This method is called once with the initial value and again
                 // whenever data at this location is updated.
                 String value = dataSnapshot.getValue(String.class);
@@ -56,7 +58,7 @@ public class MainActivity extends AppCompatActivity {
             }
 
             @Override
-            public void onCancelled(DatabaseError error) {
+            public void onCancelled(@NonNull DatabaseError error) {
                 // Failed to read value
                 Log.w(TAG, "Failed to read value.", error.toException());
             }

--- a/database/app/src/main/java/com/google/firebase/referencecode/database/OfflineActivity.java
+++ b/database/app/src/main/java/com/google/firebase/referencecode/database/OfflineActivity.java
@@ -172,7 +172,7 @@ public class OfflineActivity extends AppCompatActivity {
         final DatabaseReference connectedRef = database.getReference(".info/connected");
         connectedRef.addValueEventListener(new ValueEventListener() {
             @Override
-            public void onDataChange(DataSnapshot snapshot) {
+            public void onDataChange(@NonNull DataSnapshot snapshot) {
                 boolean connected = snapshot.getValue(Boolean.class);
                 if (connected) {
                     DatabaseReference con = myConnectionsRef.push();
@@ -190,7 +190,7 @@ public class OfflineActivity extends AppCompatActivity {
             }
 
             @Override
-            public void onCancelled(DatabaseError error) {
+            public void onCancelled(@NonNull DatabaseError error) {
                 Log.w(TAG, "Listener was cancelled at .info/connected");
             }
         });

--- a/database/app/src/main/java/com/google/firebase/referencecode/database/QueryActivity.java
+++ b/database/app/src/main/java/com/google/firebase/referencecode/database/QueryActivity.java
@@ -69,7 +69,7 @@ public class QueryActivity extends AppCompatActivity {
         mMessagesRef = databaseReference.child("messages");
         mMessagesListener = new ValueEventListener() {
             @Override
-            public void onDataChange(DataSnapshot dataSnapshot) {
+            public void onDataChange(@NonNull DataSnapshot dataSnapshot) {
                 // New data at this path. This method will be called after every change in the
                 // data at this path or a subpath.
 
@@ -88,7 +88,7 @@ public class QueryActivity extends AppCompatActivity {
             }
 
             @Override
-            public void onCancelled(DatabaseError error) {
+            public void onCancelled(@NonNull DatabaseError error) {
                 // Could not successfully listen for data, log the error
                 Log.e(TAG, "messages:onCancelled:" + error.getMessage());
             }
@@ -106,11 +106,11 @@ public class QueryActivity extends AppCompatActivity {
         myTopPostsQuery.addChildEventListener(new ChildEventListener() {
             // TODO: implement the ChildEventListener methods as documented above
             // [START_EXCLUDE]
-            public void onChildAdded(DataSnapshot dataSnapshot, String s) { }
-            public void onChildChanged(DataSnapshot dataSnapshot, String s) { }
-            public void onChildRemoved(DataSnapshot dataSnapshot) { }
-            public void onChildMoved(DataSnapshot dataSnapshot, String s) { }
-            public void onCancelled(DatabaseError databaseError) { }
+            public void onChildAdded(@NonNull DataSnapshot dataSnapshot, String s) { }
+            public void onChildChanged(@NonNull DataSnapshot dataSnapshot, String s) { }
+            public void onChildRemoved(@NonNull DataSnapshot dataSnapshot) { }
+            public void onChildMoved(@NonNull DataSnapshot dataSnapshot, String s) { }
+            public void onCancelled(@NonNull DatabaseError databaseError) { }
             // [END_EXCLUDE]
         });
         // [END basic_query]
@@ -125,14 +125,14 @@ public class QueryActivity extends AppCompatActivity {
         // My top posts by number of stars
         myTopPostsQuery.addValueEventListener(new ValueEventListener() {
             @Override
-            public void onDataChange(DataSnapshot dataSnapshot) {
+            public void onDataChange(@NonNull DataSnapshot dataSnapshot) {
                 for (DataSnapshot postSnapshot: dataSnapshot.getChildren()) {
                     // TODO: handle the post
                 }
             }
 
             @Override
-            public void onCancelled(DatabaseError databaseError) {
+            public void onCancelled(@NonNull DatabaseError databaseError) {
                 // Getting Post failed, log a message
                 Log.w(TAG, "loadPost:onCancelled", databaseError.toException());
                 // ...

--- a/database/app/src/main/java/com/google/firebase/referencecode/database/ReadAndWriteSnippets.java
+++ b/database/app/src/main/java/com/google/firebase/referencecode/database/ReadAndWriteSnippets.java
@@ -107,8 +107,9 @@ public class ReadAndWriteSnippets {
     // [START post_stars_transaction]
     private void onStarClicked(DatabaseReference postRef) {
         postRef.runTransaction(new Transaction.Handler() {
+            @NonNull
             @Override
-            public Transaction.Result doTransaction(MutableData mutableData) {
+            public Transaction.Result doTransaction(@NonNull MutableData mutableData) {
                 Post p = mutableData.getValue(Post.class);
                 if (p == null) {
                     return Transaction.success(mutableData);

--- a/firestore/app/src/main/java/com/google/example/firestore/DocSnippets.java
+++ b/firestore/app/src/main/java/com/google/example/firestore/DocSnippets.java
@@ -531,7 +531,7 @@ public class DocSnippets {
 
         db.runTransaction(new Transaction.Function<Void>() {
             @Override
-            public Void apply(Transaction transaction) throws FirebaseFirestoreException {
+            public Void apply(@NonNull Transaction transaction) throws FirebaseFirestoreException {
                 DocumentSnapshot snapshot = transaction.get(sfDocRef);
 
                 // Note: this could be done without a transaction
@@ -563,7 +563,7 @@ public class DocSnippets {
 
         db.runTransaction(new Transaction.Function<Double>() {
             @Override
-            public Double apply(Transaction transaction) throws FirebaseFirestoreException {
+            public Double apply(@NonNull Transaction transaction) throws FirebaseFirestoreException {
                 DocumentSnapshot snapshot = transaction.get(sfDocRef);
                 double newPopulation = snapshot.getDouble("population") + 1;
                 if (newPopulation <= 1000000) {

--- a/firestore/app/src/main/java/com/google/example/firestore/SolutionAggregation.java
+++ b/firestore/app/src/main/java/com/google/example/firestore/SolutionAggregation.java
@@ -1,5 +1,7 @@
 package com.google.example.firestore;
 
+import androidx.annotation.NonNull;
+
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.FirebaseFirestore;
@@ -54,7 +56,7 @@ public class SolutionAggregation {
         // In a transaction, add the new rating and update the aggregate totals
         return db.runTransaction(new Transaction.Function<Void>() {
             @Override
-            public Void apply(Transaction transaction) throws FirebaseFirestoreException {
+            public Void apply(@NonNull Transaction transaction) throws FirebaseFirestoreException {
                 Restaurant restaurant = transaction.get(restaurantRef).toObject(Restaurant.class);
 
                 // Compute new number of ratings


### PR DESCRIPTION
This PR should add nullability annotations to some of our java snippets.
Their absence doesn't really break any code, but adding it prevents the IDE from showing warnings that some variable might be null.