### PR TITLE
refactor(rtdb): update comment about default values nullability

### DIFF
--- a/database/app/src/main/java/com/google/firebase/referencecode/database/kotlin/models/User.kt
+++ b/database/app/src/main/java/com/google/firebase/referencecode/database/kotlin/models/User.kt
@@ -4,8 +4,8 @@ import com.google.firebase.database.IgnoreExtraProperties
 
 // [START rtdb_user_class]
 @IgnoreExtraProperties
-data class User(val username: String? = null, val email: String? = null) {
-    // Null default values create a no-argument default constructor, which is needed
+data class User(val username: String? = null, val email: String = "") {
+    // Default values create a no-argument default constructor, which is needed
     // for deserialization from a DataSnapshot.
 }
 // [END rtdb_user_class]


### PR DESCRIPTION
The code comment here **incorrectly** claims that the default values for data classes used by the Realtime Database **must** be nullable, which is not true.

This PR should update that comment and also change the `email` field to not be null so that we can demonstrate that both options are valid.