### PR TITLE
refactor(analytics): migrate out of KTX

### DIFF
--- a/analytics/app/build.gradle.kts
+++ b/analytics/app/build.gradle.kts
@@ -35,7 +35,7 @@ android {
 dependencies {
     implementation("androidx.legacy:legacy-support-v4:1.0.0")
     implementation("androidx.appcompat:appcompat:1.6.1")
-    implementation("com.google.firebase:firebase-analytics:21.4.0")
+    implementation("com.google.firebase:firebase-analytics:21.5.0")
     // Ironsource and AppLovin libraries used for ad_impression snippets
     implementation("com.applovin:applovin-sdk:11.5.1")
     implementation("com.ironsource.sdk:mediationsdk:7.2.4.1")

--- a/analytics/app/src/main/java/com/google/firebase/example/analytics/kotlin/MainActivity.kt
+++ b/analytics/app/src/main/java/com/google/firebase/example/analytics/kotlin/MainActivity.kt
@@ -6,10 +6,10 @@ import androidx.appcompat.app.AppCompatActivity
 import com.applovin.mediation.MaxAd
 import com.applovin.mediation.MaxAdRevenueListener
 import com.google.firebase.analytics.FirebaseAnalytics
-import com.google.firebase.analytics.ktx.analytics
-import com.google.firebase.analytics.ktx.logEvent
+import com.google.firebase.analytics.analytics
+import com.google.firebase.analytics.logEvent
 import com.google.firebase.example.analytics.R
-import com.google.firebase.ktx.Firebase
+import com.google.firebase.Firebase
 import com.ironsource.mediationsdk.impressionData.ImpressionData
 import com.ironsource.mediationsdk.impressionData.ImpressionDataListener
 


### PR DESCRIPTION
Now that firebase/firebase-android-sdk#5457 has been fixed, we can finally migrate analytics out of ktx