### PR TITLE
ci: use cmdline-tools instead of sdk tools

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Check Snippets
       run: python scripts/checksnippets.py
     - name: Install NDK
-      run: echo "y" | sudo ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;21.0.6113669" --sdk_root=${ANDROID_SDK_ROOT}
+      run: echo "y" | sudo ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager --install "ndk;21.0.6113669" --sdk_root=${ANDROID_SDK_ROOT}
     - name: Build with Gradle (Pull Request)
       run: ./build_pull_request.sh
       if: github.event_name == 'pull_request'


### PR DESCRIPTION
CI started [breaking](https://github.com/firebase/snippets-android/actions/runs/7610154648/job/20722905877?pr=521) due to https://github.com/actions/runner-images/issues/8952
Specifically, the "Install NDK" step would fail with the following error:

```
sudo: a terminal is required to read the password; either use the -S option to read from standard input or configure an askpass helper
sudo: a password is required
```

This PR should fix it by using Android's "Command-line tools" rather than the "SDK tools".