### PR TITLE
chore: update Vertex AI to 16.0.0-beta06

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ lifecycleRuntimeKtx = "2.8.6"
 activityCompose = "1.9.2"
 composeBom = "2024.09.02"
 reactiveStreams = "1.0.4"
-vertexAI = "16.0.0-beta04"
+vertexAI = "16.0.0-beta06"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }


### PR DESCRIPTION
The fix for firebase/firebase-android-sdk#6271 has been released with this version