### PR TITLE
ci: update actions versions and remove NDK install

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -10,15 +10,14 @@ jobs:
     # https://github.com/firebase/snippets-android/issues/602
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v2
-    - name: set up JDK 17
-      uses: actions/setup-java@v1
-      with:
-        java-version: 17
+    - uses: actions/checkout@v4
     - name: Check Snippets
       run: python scripts/checksnippets.py
-    - name: Install NDK
-      run: echo "y" | sudo ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager --install "ndk;21.0.6113669" --sdk_root=${ANDROID_SDK_ROOT}
+    - name: set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: 17
+        distribution: temurin
     - name: Build with Gradle (Pull Request)
       run: ./build_pull_request.sh
       if: github.event_name == 'pull_request'


### PR DESCRIPTION
This PR should:

- Update `actions/setup-java@v1` -> `actions/setup-java@v4`
    Note that v4 asks for a distribution to be specified. `temurin` is the one used by our SDKs: https://github.com/firebase/firebase-android-sdk/blob/0ce193f352d44be79b976b48b9a2e79c4caedbdf/.github/workflows/build-release-artifacts.yml#L21
- Update `actions/checkout@v2` -> `actions/checkout@v4`
- Move "Check Snippets" to be the first step.
- Remove the "Install NDK" step, which was only necessary for the MLKit snippets, which we no longer build since #424.