### PR TITLE
pin the functions SDK version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,9 @@ fun isBlockListed(candidate: ModuleComponentIdentifier): Boolean {
             "com.applovin:applovin-sdk",
             "com.ironsource.sdk:mediationsdk",
             "com.google.guava",
-            "com.github.bumptech.glide"
+            "com.github.bumptech.glide",
+            // TODO(thatfiredev): remove functions once https://github.com/firebase/firebase-android-sdk/issues/6522 is fixed
+            "com.google.firebase:firebase-functions"
     ).any { keyword ->
         keyword in candidate.toString().lowercase()
     }

--- a/functions/app/build.gradle.kts
+++ b/functions/app/build.gradle.kts
@@ -40,5 +40,7 @@ dependencies {
 
     // Add the dependency for the Cloud Functions library
     // When using the BoM, you don't specify versions in Firebase library dependencies
-    implementation("com.google.firebase:firebase-functions")
+    // TODO(thatfiredev): remove the pinned dependency version when
+    //   https://github.com/firebase/firebase-android-sdk/issues/6522 is fixed
+    implementation("com.google.firebase:firebase-functions:21.0.0")
 }


### PR DESCRIPTION
dpebot keeps trying to bump the Firebase BoM in the Functions quickstart, but runs into a build error due to firebase/firebase-android-sdk#6522

This PR should pin the Functions SDK version to the last working one before the break.
Once a new version of functions comes out with the fix for firebase/firebase-android-sdk#6522 we should revert this change.