### PR TITLE
chore: remove firebase-functions version pin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,9 +33,7 @@ fun isBlockListed(candidate: ModuleComponentIdentifier): Boolean {
             "com.applovin:applovin-sdk",
             "com.ironsource.sdk:mediationsdk",
             "com.google.guava",
-            "com.github.bumptech.glide",
-            // TODO(thatfiredev): remove functions once https://github.com/firebase/firebase-android-sdk/issues/6522 is fixed
-            "com.google.firebase:firebase-functions"
+            "com.github.bumptech.glide"
     ).any { keyword ->
         keyword in candidate.toString().lowercase()
     }

--- a/functions/app/build.gradle.kts
+++ b/functions/app/build.gradle.kts
@@ -43,9 +43,7 @@ dependencies {
 
     // Add the dependency for the Cloud Functions library
     // When using the BoM, you don't specify versions in Firebase library dependencies
-    // TODO(thatfiredev): remove the pinned dependency version when
-    //   https://github.com/firebase/firebase-android-sdk/issues/6522 is fixed
-    implementation("com.google.firebase:firebase-functions:21.0.0")
+    implementation("com.google.firebase:firebase-functions")
 
     // For streaming callable Cloud Functions
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactive:1.11.0")


### PR DESCRIPTION
This was originally added in #607 due to a bug in the SDK. But that bug has been fixed, so it should be safe to remove this version pin.